### PR TITLE
hotfix: gitlab: handled GitLab's 'work_items', which used to be called 'issues'

### DIFF
--- a/regzbot/_repsources/_gitlab.py
+++ b/regzbot/_repsources/_gitlab.py
@@ -255,7 +255,10 @@ class GlRepSrc(regzbot._repsources._trackers._repsrc):
 
     def supports_url(self, url_lowered, url_parsed):
         if url_lowered.startswith(self.serverurl):
-            id = url_lowered.removeprefix('%s/-/issues/' % self.serverurl)
+            if 'work_items' in url_lowered:
+                id = url_lowered.removeprefix('%s/-/work_items/' % self.serverurl)
+            else:
+                id = url_lowered.removeprefix('%s/-/issues/' % self.serverurl)
             return id.strip('/')
 
     def updated_threads(self, since):


### PR DESCRIPTION
GitLab renamed 'issues' to 'work_items':
https://gitlab.com/groups/gitlab-org/-/work_items/6033