### PR TITLE
chore/increase offline tests coverage 

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,7 @@
+[run]
+source = regzbot
+omit = regzbot/testing*.py
+
+[report]
+fail_under = 60
+show_missing = true

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ __pycache__
 *.pyc
 *.pyo
 *.swp
+.coverage

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,29 @@
+Codebase overview
+=================
+
+| Area | Files | Role |
+|------|-------|------|
+| Core + DB | `__init__.py` | Regression model, `GitTree`/`GitBranch`, `ReportThread`, `run()`/`generate_web()`/`report()` |
+| Bot commands | `_rbcmd.py` | Parse and execute `#regzbot` subcommands |
+| CLI | `commandl.py` | argparse-based subcommands |
+| Web export | `export_web.py` | Static HTML generation |
+| Mail reports | `export_mail.py` | Weekly text/mail report layout |
+| CSV export | `export_csv.py` | CSV-oriented export (tests) |
+| Lore ingestion | `_repsources/_lore.py` | NNTP and HTTPS access to lore archives |
+| Tracker sources | `_bugzilla.py`, `_gitlab.py`, `_github.py`, `_generic.py` | Tracker-specific API integrations |
+| Tests | `testing_online.py`, `testing_offline.py`, `testing_trackers.py`, `testdata/*` | Offline/online/tracker tests/expected results |
+
+Report sources (pluggable backends):
+
+| Source | Implementation | Notes |
+|--------|----------------|-------|
+| **lore** (NNTP/HTTPS) | `_repsources/_lore.py` | Primary source; kernel mailing list archives |
+| **bugzilla.kernel.org** | `_repsources/_bugzilla.py` | REST API with API key |
+| **GitLab** | `_repsources/_gitlab.py` | Issue tracker integration |
+| **GitHub** | `_repsources/_github.py` | Issue tracker integration |
+
+Tracker polling logic lives in `_repsources/_trackers.py`.
+
 Sign-off Process
 ================
 

--- a/README.md
+++ b/README.md
@@ -5,24 +5,76 @@ driven Linux kernel development process. It's actually used in the field, but
 still in a alpha stage: more adjustments are needed to make it better suite the
 its intended purpose.
 
-To get an impression how regression tracking with regzbot is performed in
-practice, see the
-[about page for the Linux kernel regression tracking efforts](https://linux-regtracking.leemhuis.info/about/)
-and
-[the list of regressions regzbot currently tracks](https://linux-regtracking.leemhuis.info/regzbot/mainline/).
-If you want to interact with regzbot, check out
-[getting started with regzbot](docs/getting_started.md) or the bots
-[reference documentation](docs/reference.md).
+Anyone can make regzbot track a regression by adding a command such as
+`#regzbot introduced: <commit-id>` to an email sent to the Linux kernel mailing
+list (LKML) or `regressions@lists.linux.dev`. Regzbot later notices fixes
+automatically when a change points to the report using existing conventions such
+as `Link:` or `Closes:` tags, which avoids extra work for developers. If those
+links were forgotten, or if more details need to be recorded, the documentation
+below lists other `#regzbot` commands.
 
-To install or develop for regzbot, see the [installation documentation](docs/installation.md).
+Kernel development treats regressions with high urgency — fixing them takes
+priority over new features. Before automated tracking, regression reports on
+mailing lists could disappear in the traffic. Regzbot automates the
+bookkeeping: open regressions appear on a public dashboard, and periodic mail
+summaries list outstanding issues ahead of releases. See the kernel
+documentation for
+[reporting regressions](https://docs.kernel.org/admin-guide/reporting-regressions.html) and
+[handling regressions](https://docs.kernel.org/process/handling-regressions.html).
 
-## Licensing
+## Scope
 
-Rezbot is available under the LGPL 2.1; see the file COPYING for details.
+Regzbot focuses on Linux kernel regressions in mainline, the latest mainline
+release, and the stable series derived from it. Tracking is best-effort:
+regzbot helps reports stay visible and helps connect fixes to reports, but it
+does not guarantee every regression is tracked or fixed.
 
-Regzbot was started by Thorsten Leemhuis as part of a project that has received
-funding from the European Union’s Horizon 2020 research and innovation
+It is not intended to track ordinary bugs, monitor every bug tracker used by
+kernel subsystems, or produce complete regression statistics.
+
+The public dashboards below show regression tracking in practice: start with
+the mainline regression list to see currently tracked issues, while this README
+gives background on the Linux kernel regression tracking effort. The
+documentation links cover reporting, fixing, installation, and development.
+
+### Public dashboards
+
+| Resource | URL |
+|----------|-----|
+| Tracked regressions (mainline) | https://linux-regtracking.leemhuis.info/regzbot/mainline/ |
+| All views (index) | https://linux-regtracking.leemhuis.info/regzbot/ |
+| About the effort | [README](README.md) |
+| Weekly reports (lore search) | [lore.kernel.org](https://lore.kernel.org/lkml/?q=%22Linux+regressions+report%22+f%3Aregzbot) |
+
+### Documentation
+
+* [Getting started](docs/getting_started.md) — report, fix, or update a tracked regression
+* [Reference](docs/reference.md) — full `#regzbot` command syntax
+* [Installation](docs/installation.md) — run your own instance
+* [Contributing](CONTRIBUTING.md) — codebase layout and development
+
+## History
+
+Linux had no formal regression tracking for most of its history. Rafael J.
+Wysocki tracked regressions for several years in the 2000s, but that effort
+ended in 2012.
+
+Thorsten Leemhuis restarted the work manually in 2017. That showed the value of
+regression tracking, but also that manual tracking did not scale.
+
+Development of regzbot started in 2021, and Thorsten began tracking
+regressions with it later that year.
+
+## Licensing and funding
+
+Regzbot is available under the LGPL 2.1; see the file COPYING for details.
+
+Regzbot was started by Thorsten Leemhuis as part of a project that received
+funding from the European Union's Horizon 2020 research and innovation
 programme under grant agreement No 871528.
 
-Since May 2022 regzbot development and the Linux kernel regression tracking
-efforts performed by Thorsten are supported with funds from Meta.
+Starting in May 2022, regzbot development and the Linux kernel regression
+tracking efforts performed by Thorsten were supported with funds from Meta for
+about two years. Regzbot is now part of [KernelCI](https://kernelci.org/),
+where it contributes to coordinated regression tracking across the kernel
+ecosystem and receives funding for current development.

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -3,6 +3,19 @@
 [[_TOC_]]
 
 
+## Background
+
+A **regression** is a change in the kernel that breaks something that previously
+worked — degraded performance, a feature that stops working, or hardware that is
+no longer recognized. Regressions are treated with higher urgency than ordinary
+bugs; see the kernel documentation on
+[reporting regressions](https://docs.kernel.org/admin-guide/reporting-regressions.html) and
+[handling regressions](https://docs.kernel.org/process/handling-regressions.html).
+
+This guide focuses on the `#regzbot` commands reporters and developers can use
+to add or update tracked regressions.
+
+
 ## Why and how to make regzbot track a Linux kernel regression
 
 When reporting a Linux kernel regression it is in your interest to make [regzbot](https://gitlab.com/knurd42/regzbot/) aware of the issue, as that ensures the report won't accidentally fall though the cracks; it also makes sure leading developers see the issue via the tracked regression website [or the weekly reports, which are not sent yet, but soon will be].
@@ -24,6 +37,18 @@ See below for a few other examples how to specify ranges, how to modify the vers
 Regzbot is designed to normally not create any additional chores for Linux kernel developers like you. But for that to work it's important you do something the [Linux kernel documentation specifies for a while already](https://www.kernel.org/doc/html/latest/process/submitting-patches.html): when fixing a regression, include a `Link:` tag with the URL to the report in the [mailing list archives on lore.kernel.org](https://lore.kernel.org/). This aspect is important for regzbot, as it allows the bot to connect the fix with the regression's report. That's needed so regzbot can do things automatically that otherwise would mean manual work for somebody — like marking the regression as resolved once the fix hits mainline.
 
 But sometimes you might want to do more with regzbot, like specifying a culprit exactly after a bisection or marking a regression as resolved. The text below explains how to do these and other things; the instructions there also will tell you how to use regzbot to track regressions for your own code or the subsystem you maintain, as that will make sure none fall through the cracks unnoticed.
+
+
+## How to help keep tracking accurate
+
+If a tracked issue turns out not to be a regression, if discussion moved
+elsewhere, or if important details such as the title or introduced range are
+wrong, please reply publicly and include the appropriate `#regzbot` command.
+That keeps the public record clear and helps regzbot show useful status.
+
+Developers do not need to CC individual regression trackers on every follow-up.
+Keep `regressions@lists.linux.dev` in the loop and use `Link:` or `Closes:`
+tags that point to the report when posting fixes.
 
 
 ## More regzbot features relevant for both reporters and developers

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -47,6 +47,26 @@ Now you are ready to run regzbot
 
 It will generate web reports at `~/.cache/regzbot/websites/`
 
+## available commands
+
+| Command | Purpose |
+|---------|---------|
+| `setup` | Initialize database, register sources, first Git tree sync |
+| `run` | Full update cycle (sources → git → web) |
+| `pages` | Regenerate web output only |
+| `report` | Build interactive mail reports (operator sends manually) |
+| `recheck` | Reprocess specific message IDs |
+| `test` | Run offline/online test suites |
+
+## data paths
+
+| Path | Contents |
+|------|----------|
+| `~/.local/share/regzbot/database.db` | SQLite database (tracked regressions, processed message IDs, repository metadata) |
+| `~/.cache/regzbot/gittrees/` | Local Git clones (mainline, next, stable) |
+| `~/.cache/regzbot/websites/` | Generated static HTML output |
+| `~/.config/regzbot/regzbot.cfg` | Configuration file (API keys) |
+
 ## Development tools
 
 ### Ruff

--- a/regzbot/__init__.py
+++ b/regzbot/__init__.py
@@ -2249,23 +2249,6 @@ class RegressionBasic:
                 yield cls(*dbresult)
 
     @classmethod
-    def get_by_link(cls, link):
-        tmpstring = link
-        if tmpstring.startswith("https://"):
-            tmpstring = tmpstring.removeprefix("https://")
-        elif tmpstring.startswith("http://"):
-            tmpstring = tmpstring.removeprefix("http://")
-
-        if tmpstring.startswith("lore.kernel.org/"):
-            _, _, tmpstring = tmpstring.split("/", maxsplit=2)
-            msgid, _, _ = tmpstring.partition("/")
-            for regression in cls.get_by_entry(urldecode(msgid)):
-                return regression
-        else:
-            logger.warning("RegressionBasic.get_by_link(%s): unsupported domain ", link)
-        return None
-
-    @classmethod
     def get_by_url(cls, url):
         try:
             reptrd_pointedto = ReportThreadOffline.from_url(url)
@@ -2386,93 +2369,6 @@ class RegressionBasic:
             self.subject,
             self.introduced,
         )
-
-    def __create_dup(self, url, gmtime):
-        subject = self.subject
-        repsrc, entry = ReportSource.get_by_url(url)
-
-        # defaults that normally will be overridden
-        authorname = "Unknown"
-        authormail = None
-
-        # create regression
-        return self.__create_obsolete(
-            self.introduced,
-            self.gitbranchid,
-            repsrc.repsrcid,
-            entry,
-            gmtime,
-            subject,
-            authorname,
-            authormail,
-        )
-
-    def _dupof_direct(
-        self, regression_other, gmtime, msgid, msgsubject, authorname, repsrcid, *, history=True
-    ):
-        if self.regid == regression_other.regid:
-            logger.warning(
-                'regression[%s, "%s"]: request to mark this a as duplicate of ourselves; aborting',
-                self.regid,
-                self.subject,
-            )
-            # FIXME properly
-            sys.exit(1)
-
-        if self.solved_subject is None:
-            self.solved_subject = regression_other.subject
-
-        self.solved_gmtime = gmtime
-        self.solved_duplicateof = regression_other.regid
-
-        self._db_update_solved()
-
-        logger.info(
-            'regression[%s, "%s"]: marked as duplicate of regression Regression[%s, "%s"])',
-            self.regid,
-            self.subject,
-            regression_other.regid,
-            regression_other.subject,
-        )
-        if history:
-            # make sure this is mentioned in the other regression, too
-            RegHistory.event(
-                regression_other.regid,
-                gmtime,
-                msgid,
-                self.solved_subject,
-                authorname,
-                repsrcid=repsrcid,
-                regzbotcmd='dup: the regression "%s" was marked as duplicate of this'
-                % (self.subject),
-            )
-
-    def dupof(self, tagload, gmtime, msgid, msgsubject, authorname, repsrcid):
-        def parse(tagload):
-            tagload = tagload.split(maxsplit=1)
-            url = tagload[0]
-            if len(tagload) > 1:
-                subject = tagload[1]
-            else:
-                subject = None
-            return url, subject
-
-        urldup, self.solved_subject = parse(tagload)
-
-        regression_other = self.get_by_link(urldup)
-        if not regression_other:
-            regression_other = self.__create_dup(urldup, gmtime)
-            RegHistory.event(
-                regression_other.regid,
-                gmtime,
-                msgid,
-                msgsubject,
-                authorname,
-                repsrcid=repsrcid,
-                regzbotcmd="introduced: %s [implicit, due to usage of 'dup-of']" % self.introduced,
-            )
-
-        self._dupof_direct(regression_other, gmtime, msgid, msgsubject, authorname, repsrcid)
 
     def fixed(self, gmtime, commit_hexsha, commit_subject, gitbranchid):
         if self.solved_reason == "fixed":
@@ -2651,36 +2547,6 @@ class RegressionBasic:
         self.solved_repsrcid = repsrcid
         self.solved_repentry = msgid
         self._db_update_solved()
-
-    def update_author(self, entry, tagload):
-        from email.utils import parseaddr
-
-        author, authormail = parseaddr(tagload)
-
-        dbcursor = DBCON.cursor()
-        dbcursor.execute(
-            """UPDATE actmonitor
-                            SET authorname = (?), authormail = (?)
-                            WHERE regid=(?) and entry=(?)""",
-            (author, authormail, self.regid, entry),
-        )
-        logger.debug(
-            '[db regressions] author is now %s, authormail now %s (regid:%s; subject:"%s")',
-            author,
-            authormail,
-            self.regid,
-            self.subject,
-        )
-        logger.info(
-            'regression[%s, "%s"]: author is now %s, authormail now %s',
-            self.regid,
-            self.subject,
-            author,
-            authormail,
-        )
-
-        self.author = author
-        self.author = authormail
 
     def title(self, tagload):
         dbcursor = DBCON.cursor()
@@ -3508,7 +3374,6 @@ class RepDownloadError(Exception):
     pass
 
 
-
 def db_ensure_cursor(dbcursor=None):
     return DBCON.cursor() if dbcursor is None else dbcursor
 
@@ -3627,45 +3492,6 @@ def timendate_dt_to_gmtime(dt):
 
 def timendate_gmtime_to_dt(gmtime):
     return datetime.datetime.fromtimestamp(gmtime, tz=datetime.timezone.utc)
-
-
-def parse_link(url):
-    tmpstring = url
-
-    if tmpstring.startswith("https://"):
-        tmpstring = tmpstring.removeprefix("https://")
-    elif tmpstring.startswith("http://"):
-        tmpstring = tmpstring.removeprefix("http://")
-
-    domain = mlist = msgid = None
-    if tmpstring.startswith("lore.kernel.org") or tmpstring.startswith("lkml.kernel.org"):
-        domain = "lore.kernel.org"
-        tmplist = tmpstring.split("/", maxsplit=2)
-        if len(tmplist) <= 2:
-            logger.debug("Ignoring %s, failed to parse", url)
-            return None, None, None
-
-        mlist = tmplist[1]
-        tmpstring = tmplist[2]
-
-        msgid, _, _ = tmpstring.partition("/")
-
-        if mlist == "r":
-            if tmpstring.startswith("lkml.kernel.org"):
-                mlist = "lkml"
-            else:
-                # FIXMELATER: this is the lore redirector; for now just assume it redirecting to LKML, which likely needs fixing later
-                mlist = "lkml"
-    elif tmpstring.startswith("bugzilla.kernel.org"):
-        bugid = tmpstring.removeprefix("bugzilla.kernel.org/show_bug.cgi?id=")
-        if bugid.isnumeric():
-            msgid = bugid
-            domain = "bugzilla.kernel.org"
-        else:
-            logger.debug("Tried to get bugid from %s, but failed", url)
-    else:
-        logger.debug("Tried to get msgid from %s, but don't known how to handle that domain", url)
-    return domain, mlist, msgid
 
 
 def basicressource_checkdir_exists(directory, create=False):

--- a/regzbot/__init__.py
+++ b/regzbot/__init__.py
@@ -94,16 +94,14 @@ class RegzbotDbMeta:
 
     @staticmethod
     def update(dbcursor=None):
-        if dbcursor is None:
-            dbcursor = DBCON.cursor()
+        dbcursor = db_ensure_cursor(dbcursor)
 
         if not RegzbotDbMeta.table_exists("RegzbotState", dbcursor):
             RegzbotState.db_create(1, dbcursor)
 
     @staticmethod
     def table_exists(tablename, dbcursor=None):
-        if dbcursor is None:
-            dbcursor = DBCON.cursor()
+        dbcursor = db_ensure_cursor(dbcursor)
         dbresult = dbcursor.execute(
             "SELECT name FROM sqlite_master WHERE type='table' AND name=(?)", (tablename,)
         ).fetchone()
@@ -113,8 +111,7 @@ class RegzbotDbMeta:
 
     @staticmethod
     def set_tableversion(tablename, version, dbcursor=None):
-        if dbcursor is None:
-            dbcursor = DBCON.cursor()
+        dbcursor = db_ensure_cursor(dbcursor)
         dbcursor.execute(
             """
             INSERT INTO RegzbotMeta
@@ -135,8 +132,7 @@ class RegzbotState:
 
     @staticmethod
     def get(attribute, dbcursor=None):
-        if dbcursor is None:
-            dbcursor = DBCON.cursor()
+        dbcursor = db_ensure_cursor(dbcursor)
         dbresult = dbcursor.execute(
             "SELECT value FROM RegzbotState WHERE attribute=(?)", (attribute,)
         ).fetchone()
@@ -146,8 +142,7 @@ class RegzbotState:
 
     @staticmethod
     def set(attribute, value, dbcursor=None):
-        if dbcursor is None:
-            dbcursor = DBCON.cursor()
+        dbcursor = db_ensure_cursor(dbcursor)
         dbcursor.execute(
             """
             INSERT OR REPLACE INTO RegzbotState
@@ -173,8 +168,7 @@ class RecordProcessedMsgids:
 
     @staticmethod
     def add(msgid, gmtime, dbcursor=None):
-        if dbcursor is None:
-            dbcursor = DBCON.cursor()
+        dbcursor = db_ensure_cursor(dbcursor)
 
         dbcursor.execute(
             """INSERT INTO msgidrecord
@@ -186,8 +180,7 @@ class RecordProcessedMsgids:
 
     @staticmethod
     def check_presence(msgid, gmtime=None, dbcursor=None):
-        if dbcursor is None:
-            dbcursor = DBCON.cursor()
+        dbcursor = db_ensure_cursor(dbcursor)
 
         dbresult = dbcursor.execute(
             "SELECT * FROM msgidrecord WHERE msgid=(?)", (msgid,)
@@ -931,8 +924,7 @@ class RegActivityMonitor:
         return dbcursor.lastrowid
 
     def delete(self, dbcursor=None):
-        if not dbcursor:
-            dbcursor = DBCON.cursor()
+        dbcursor = db_ensure_cursor(dbcursor)
 
         # delete related activities
         for activity in RegActivityEvent.getall_by_actimonid(self.actimonid):
@@ -1157,8 +1149,7 @@ class RegActivityEvent:
             )""")
 
     def delete(self, dbcursor=None):
-        if not dbcursor:
-            dbcursor = DBCON.cursor()
+        dbcursor = db_ensure_cursor(dbcursor)
 
         # delete related activities
         if self.repsrcid and ReportSource.get_by_id(self.repsrcid, dbcursor).ismail():
@@ -1453,8 +1444,7 @@ class RegBackburner:
 
     @staticmethod
     def remove(regid, dbcursor=None):
-        if dbcursor is None:
-            dbcursor = DBCON.cursor()
+        dbcursor = db_ensure_cursor(dbcursor)
         dbresult = dbcursor.execute(
             "SELECT subject FROM regbackburner WHERE regid=(?)", (regid,)
         ).fetchone()
@@ -1502,8 +1492,7 @@ class RegHistory:
             )""")
 
     def delete(self, dbcursor=None):
-        if not dbcursor:
-            dbcursor = DBCON.cursor()
+        dbcursor = db_ensure_cursor(dbcursor)
 
         if self.repsrcid and ReportSource.get_by_id(self.repsrcid, dbcursor).ismail():
             RecordProcessedMsgids.delete(self.entry)
@@ -1757,8 +1746,7 @@ class RegLink:
                 yield cls(*dbresult)
 
     def delete(self, dbcursor=None):
-        if not dbcursor:
-            dbcursor = DBCON.cursor()
+        dbcursor = db_ensure_cursor(dbcursor)
 
         dbcursor.execute(
             """DELETE FROM reglinks
@@ -2092,8 +2080,7 @@ class RegressionBasic:
         )
 
     def delete(self, dbcursor=None):
-        if not dbcursor:
-            dbcursor = DBCON.cursor()
+        dbcursor = db_ensure_cursor(dbcursor)
 
         for activity in RegActivityEvent.get_all(self.regid, onlyonce=False):
             activity.delete(dbcursor=dbcursor)
@@ -2151,8 +2138,7 @@ class RegressionBasic:
 
     @classmethod
     def get_by_regid(cls, regid, dbcursor=None):
-        if not dbcursor:
-            dbcursor = DBCON.cursor()
+        dbcursor = db_ensure_cursor(dbcursor)
         dbresult = dbcursor.execute(
             "SELECT %s FROM regressions WHERE regid=?" % RegressionBasic.DBCOLS, (regid,)
         ).fetchone()
@@ -2162,8 +2148,7 @@ class RegressionBasic:
 
     @classmethod
     def get_by_entry(cls, entry, dbcursor=None):
-        if not dbcursor:
-            dbcursor = DBCON.cursor()
+        dbcursor = db_ensure_cursor(dbcursor)
 
         dbresult = dbcursor.execute(
             "SELECT %s FROM regressions INNER JOIN actmonitor ON actmonitor.regid = regressions.regid WHERE actmonitor.entry=?"
@@ -3225,8 +3210,7 @@ class ReportSource:
         )
 
     def delete(self, dbcursor=None):
-        if not dbcursor:
-            dbcursor = DBCON.cursor()
+        dbcursor = db_ensure_cursor(dbcursor)
         dbresult = dbcursor.execute(
             """DELETE FROM reportsources
                                     WHERE repsrcid=(?)""",
@@ -3255,8 +3239,7 @@ class ReportSource:
 
     @classmethod
     def get_by_id(cls, repsrcid, dbcursor=None):
-        if not dbcursor:
-            dbcursor = DBCON.cursor()
+        dbcursor = db_ensure_cursor(dbcursor)
 
         dbresult = dbcursor.execute(
             "SELECT * FROM reportsources WHERE repsrcid=(?)", (repsrcid,)
@@ -3523,6 +3506,11 @@ class ReportSourceObsolete(ReportSource):
 
 class RepDownloadError(Exception):
     pass
+
+
+
+def db_ensure_cursor(dbcursor=None):
+    return DBCON.cursor() if dbcursor is None else dbcursor
 
 
 def db_close():

--- a/regzbot/export_mail.py
+++ b/regzbot/export_mail.py
@@ -273,7 +273,7 @@ class RegExportMailReport:
         return regressionslist
 
     @classmethod
-    def __create_mail(cls, content, treename):
+    def __create_mail(cls, content, treename, *, fixed_message_id=False):
         msg = EmailMessage()
         msg["To"] = (
             "LKML <linux-kernel@vger.kernel.org>, Linus Torvalds <torvalds@linux-foundation.org>, Linux regressions mailing list <regressions@lists.linux.dev>"
@@ -284,22 +284,26 @@ class RegExportMailReport:
             _mail_now().date(),
         )
         msg["Date"] = email.utils.formatdate(timeval=_mail_now().timestamp(), localtime=True)
-        msg["Message-ID"] = email.utils.make_msgid(domain="leemhuis.info")
+        if fixed_message_id:
+            msg["Message-ID"] = "<regzbot-testing-mailreport@example.com>"
+        else:
+            msg["Message-ID"] = email.utils.make_msgid(domain="leemhuis.info")
         msg.set_content(content, cte="quoted-printable")
         return msg
 
     @classmethod
-    def pagecreate(cls, categories, treename, lastreport_msgid):
+    def pagecreate(cls, categories, treename, lastreport_msgid, *, interactive=True):
         def repintro(report, number_issues, treename):
             intro = list()
 
-            print("Enter/Paste your intro for %s and hit Ctrl-D to save it." % treename)
-            while True:
-                try:
-                    line = input()
-                except EOFError:
-                    break
-                intro.append(line)
+            if interactive:
+                print("Enter/Paste your intro for %s and hit Ctrl-D to save it." % treename)
+                while True:
+                    try:
+                        line = input()
+                    except EOFError:
+                        break
+                    intro.append(line)
             if report:
                 intro.append("\n---\n")
 
@@ -546,16 +550,23 @@ class RegExportMailReport:
         return categories
 
     @classmethod
-    def prepare_reports(cls, categories, lastreport_msgid):
+    def prepare_reports(cls, categories, lastreport_msgid, *, interactive=True):
         reports = dict()
         for treename in categories.keys():
-            reports[treename] = cls.pagecreate(categories[treename], treename, lastreport_msgid)
+            reports[treename] = cls.pagecreate(
+                categories[treename], treename, lastreport_msgid, interactive=interactive
+            )
         return reports
 
     @classmethod
     def lastreport(cls):
-        lastreport_msgid = regzbot.RegzbotState.get("lastreport_mainline_msgid")
-        lastreport_gmtime = regzbot.RegzbotState.get("lastreport_mainline_gmtime")
+        if regzbot.is_running_citesting("offline"):
+            lastreport_gmtime = regzbot._TESTING["mail_lastreport_gmtime"]
+            lastreport_msgid = regzbot._TESTING.get("mail_lastreport_msgid")
+        else:
+            lastreport_msgid = regzbot.RegzbotState.get("lastreport_mainline_msgid")
+            lastreport_gmtime = regzbot.RegzbotState.get("lastreport_mainline_gmtime")
+
         if lastreport_gmtime:
             lastreport_gmtime = int(lastreport_gmtime)
         else:
@@ -564,17 +575,17 @@ class RegExportMailReport:
         return lastreport_gmtime, lastreport_msgid
 
     @classmethod
-    def prepare(cls):
+    def prepare(cls, *, interactive=True):
         lastreport_gmtime, lastreport_msgid = cls.lastreport()
         logger.debug("[reportmail] lastreport was %s" % lastreport_gmtime)
 
         # gather everything we need
         categories = cls.categorize(cls.listed(lastreport_gmtime), lastreport_gmtime)
-        reports = cls.prepare_reports(categories, lastreport_msgid)
+        reports = cls.prepare_reports(categories, lastreport_msgid, interactive=interactive)
         return reports, categories
 
     @classmethod
-    def publish(cls, reports):
+    def publish(cls, reports, *, interactive=True):
         report_gmtime = int(_mail_now().timestamp())
         lastreport_msgid = None
         with tempfile.TemporaryDirectory() as tmpdirname:
@@ -585,16 +596,23 @@ class RegExportMailReport:
                     continue
 
                 filename = os.path.join(tmpdirname, "%s-regzbotreport-%s" % (counter, treename))
-                msg = cls.__create_mail(report, treename)
+                msg = cls.__create_mail(report, treename, fixed_message_id=not interactive)
                 lastreport_msgid = msg["Message-ID"].strip("<>")
-                print("#" * 120)
-                print("\n%s\n" % filename)
-                print("#" * 120)
-                print(report)
+                if interactive:
+                    print("#" * 120)
+                    print("\n%s\n" % filename)
+                    print("#" * 120)
+                    print(report)
                 with open(filename, "w") as out:
                     gen = email_generator.Generator(out)
                     gen.flatten(msg)
                 counter += 1
+
+            if counter == 0:
+                return
+
+            if not interactive:
+                return
 
             print("#" * 120)
             print(
@@ -604,13 +622,23 @@ class RegExportMailReport:
             answer = input("Enter c to confirm you sent the report, anything else to abort: ")
             if answer.lower() != "c":
                 return
+
             regzbot.RegzbotState.set("lastreport_mainline_gmtime", report_gmtime)
             regzbot.RegzbotState.set("lastreport_mainline_msgid", lastreport_msgid)
 
         logger.debug("[report] generated")
 
     @classmethod
-    def compile(cls):
+    def compile(cls, *, interactive=True):
         logger.debug("[reportmail] generating")
-        reports, _categories = cls.prepare()
-        cls.publish(reports)
+        reports, _categories = cls.prepare(interactive=interactive)
+        cls.publish(reports, interactive=interactive)
+
+
+def dumpall_mail():
+    reports, categories = RegExportMailReport.prepare(interactive=False)
+    if not any(category["entries"] for category in categories.get("mainline", {}).values()):
+        return
+
+    yield reports.get("mainline", "")
+    yield "\n"

--- a/regzbot/export_mail.py
+++ b/regzbot/export_mail.py
@@ -6,6 +6,7 @@ __author__ = "Thorsten Leemhuis <linux@leemhuis.info>"
 
 from collections import Counter
 import datetime
+from email import generator as email_generator
 from email.message import EmailMessage
 import email.utils
 import tempfile
@@ -244,6 +245,32 @@ class RegExportMailReport:
         self.backburner = backburner
         self.identified = identified
         self.reporttext = reporttext
+
+    @classmethod
+    def listed(cls, lastreport_gmtime):
+        regressionslist = list()
+        for regression in RegressionMailReport.get_all(only_unsolved=True):
+            # ignore some
+            if regression._actievents:
+                last_activity = regression._actievents[-1].gmtime
+            else:
+                last_activity = regression._histevents[-1].gmtime
+            regressionslist.append(
+                cls(
+                    regression._actim_report.entry,
+                    regression.gmtime,
+                    regression.gmtime_filed,
+                    last_activity,
+                    regression.treename,
+                    regression.versionline,
+                    regression.backburner,
+                    regression.identified,
+                    regression.mailreport(lastreport_gmtime),
+                )
+            )
+
+        regressionslist.sort(key=lambda x: x.gmtime_activity, reverse=True)
+        return regressionslist
 
     @classmethod
     def __create_mail(cls, content, treename):
@@ -519,9 +546,14 @@ class RegExportMailReport:
         return categories
 
     @classmethod
-    def compile(cls):
-        logger.debug("[reportmail] generating")
+    def prepare_reports(cls, categories, lastreport_msgid):
+        reports = dict()
+        for treename in categories.keys():
+            reports[treename] = cls.pagecreate(categories[treename], treename, lastreport_msgid)
+        return reports
 
+    @classmethod
+    def lastreport(cls):
         lastreport_msgid = regzbot.RegzbotState.get("lastreport_mainline_msgid")
         lastreport_gmtime = regzbot.RegzbotState.get("lastreport_mainline_gmtime")
         if lastreport_gmtime:
@@ -529,44 +561,25 @@ class RegExportMailReport:
         else:
             lastreport_gmtime = int(_mail_now().timestamp())
 
+        return lastreport_gmtime, lastreport_msgid
+
+    @classmethod
+    def prepare(cls):
+        lastreport_gmtime, lastreport_msgid = cls.lastreport()
         logger.debug("[reportmail] lastreport was %s" % lastreport_gmtime)
 
         # gather everything we need
-        regressionslist = list()
+        categories = cls.categorize(cls.listed(lastreport_gmtime), lastreport_gmtime)
+        reports = cls.prepare_reports(categories, lastreport_msgid)
+        return reports, categories
 
-        for regression in RegressionMailReport.get_all(only_unsolved=True):
-            # ignore some
-            if regression._actievents:
-                last_activity = regression._actievents[-1].gmtime
-            else:
-                last_activity = regression._histevents[-1].gmtime
-            last_activity_days = regzbot.days_delta(last_activity)
-            if regression._actievents:
-                last_activity = regression._actievents[-1].gmtime
-            else:
-                last_activity = regression._histevents[-1].gmtime
-            regressionslist.append(
-                cls(
-                    regression._actim_report.entry,
-                    regression.gmtime,
-                    regression.gmtime_filed,
-                    last_activity,
-                    regression.treename,
-                    regression.versionline,
-                    regression.backburner,
-                    regression.identified,
-                    regression.mailreport(lastreport_gmtime),
-                )
-            )
-
-        regressionslist.sort(key=lambda x: x.gmtime_activity, reverse=True)
-        categories = cls.categorize(regressionslist, lastreport_gmtime)
-
+    @classmethod
+    def publish(cls, reports):
         report_gmtime = int(_mail_now().timestamp())
+        lastreport_msgid = None
         with tempfile.TemporaryDirectory() as tmpdirname:
-            for counter, treename in enumerate(categories.keys()):
-                report = cls.pagecreate(categories[treename], treename, lastreport_msgid)
-
+            counter = 0
+            for treename, report in reports.items():
                 if not report:
                     logger.info("Nothing to report for %s" % treename)
                     continue
@@ -579,11 +592,11 @@ class RegExportMailReport:
                 print("#" * 120)
                 print(report)
                 with open(filename, "w") as out:
-                    gen = email.generator.Generator(out)
+                    gen = email_generator.Generator(out)
                     gen.flatten(msg)
+                counter += 1
 
             print("#" * 120)
-
             print(
                 "Review the reports in %s and sent them using \"git send-email --from='Regzbot (on behalf of Thorsten Leemhuis) <regressions@leemhuis.info>' --suppress-cc=self --to '' %s/*\""
                 % (tmpdirname, tmpdirname)
@@ -593,6 +606,11 @@ class RegExportMailReport:
                 return
             regzbot.RegzbotState.set("lastreport_mainline_gmtime", report_gmtime)
             regzbot.RegzbotState.set("lastreport_mainline_msgid", lastreport_msgid)
-            lastreport_msgid = regzbot.RegzbotState.get("lastreport_mainline_msgid")
 
         logger.debug("[report] generated")
+
+    @classmethod
+    def compile(cls):
+        logger.debug("[reportmail] generating")
+        reports, _categories = cls.prepare()
+        cls.publish(reports)

--- a/regzbot/export_mail.py
+++ b/regzbot/export_mail.py
@@ -17,6 +17,17 @@ import regzbot
 logger = regzbot.logger
 
 
+def _mail_now():
+    mail_now = regzbot._TESTING.get("mail_now")
+    if mail_now is not None:
+        return mail_now
+    return regzbot.timendate_now()
+
+
+def _mail_days_delta(past):
+    return (_mail_now() - datetime.datetime.fromtimestamp(past, datetime.timezone.utc)).days
+
+
 class RegLinkMailReport(regzbot.RegLink):
     def __init__(self, *args):
         super().__init__(*args)
@@ -31,7 +42,7 @@ class RegLinkMailReport(regzbot.RegLink):
             ):
                 monitored = "; thread monitored."
             authored = "\n  %s days ago, by %s%s" % (
-                regzbot.days_delta(self.gmtime),
+                _mail_days_delta(self.gmtime),
                 self.author,
                 monitored,
             )
@@ -95,17 +106,17 @@ class RegressionMailReport(regzbot.RegressionFull):
                 statusline.append(", ")
 
         statusline.append("; ")
-        statusline.append(str(regzbot.days_delta(self.gmtime)))
+        statusline.append(str(_mail_days_delta(self.gmtime)))
         statusline.append(" days ago; ")
         statusline.append(str(len(self._actievents)))
         statusline.append(" activities")
         if len(self._actievents) > 0:
             statusline.append(", latest ")
-            statusline.append(str(regzbot.days_delta(self._actievents[-1].gmtime)))
+            statusline.append(str(_mail_days_delta(self._actievents[-1].gmtime)))
             statusline.append(" days ago")
 
         if self.poked:
-            statusline.append("; poked %s days ago" % regzbot.days_delta(self.poked.gmtime))
+            statusline.append("; poked %s days ago" % _mail_days_delta(self.poked.gmtime))
         statusline.append(".")
         report.append("".join(statusline))
 
@@ -166,7 +177,7 @@ class RegressionMailReport(regzbot.RegressionFull):
             report.append("* %s" % actievent.subject)
             report.append("  %s" % actievent.url())
             report.append(
-                "  %s days ago, by %s" % (regzbot.days_delta(actievent.gmtime), actievent.author)
+                "  %s days ago, by %s" % (_mail_days_delta(actievent.gmtime), actievent.author)
             )
 
             break
@@ -243,9 +254,9 @@ class RegExportMailReport:
         msg["Subject"] = "%s for %s [%s]" % (
             regzbot.REPORT_SUBJECT_PREFIX,
             treename,
-            datetime.date.today(),
+            _mail_now().date(),
         )
-        msg["Date"] = email.utils.localtime()
+        msg["Date"] = email.utils.formatdate(timeval=_mail_now().timestamp(), localtime=True)
         msg["Message-ID"] = email.utils.make_msgid(domain="leemhuis.info")
         msg.set_content(content, cte="quoted-printable")
         return msg
@@ -450,11 +461,7 @@ class RegExportMailReport:
         }
 
         for regression in regressionlist:
-            filed_days = (
-                datetime.datetime.now(datetime.timezone.utc)
-                - datetime.datetime.fromtimestamp(regression.gmtime_filed, datetime.timezone.utc)
-            ).days
-            last_activity_days = regzbot.days_delta(regression.gmtime_activity)
+            last_activity_days = _mail_days_delta(regression.gmtime_activity)
 
             if regression.backburner:
                 if lastreport_gmtime > regression.gmtime_activity:
@@ -520,7 +527,7 @@ class RegExportMailReport:
         if lastreport_gmtime:
             lastreport_gmtime = int(lastreport_gmtime)
         else:
-            lastreport_gmtime = int(datetime.datetime.now(datetime.timezone.utc).timestamp())
+            lastreport_gmtime = int(_mail_now().timestamp())
 
         logger.debug("[reportmail] lastreport was %s" % lastreport_gmtime)
 
@@ -555,7 +562,7 @@ class RegExportMailReport:
         regressionslist.sort(key=lambda x: x.gmtime_activity, reverse=True)
         categories = cls.categorize(regressionslist, lastreport_gmtime)
 
-        report_gmtime = int(datetime.datetime.now(datetime.timezone.utc).timestamp())
+        report_gmtime = int(_mail_now().timestamp())
         with tempfile.TemporaryDirectory() as tmpdirname:
             for counter, treename in enumerate(categories.keys()):
                 report = cls.pagecreate(categories[treename], treename, lastreport_msgid)

--- a/regzbot/export_web.py
+++ b/regzbot/export_web.py
@@ -1112,20 +1112,22 @@ function timeAgo(provided_date) {
         }
 
     @classmethod
+    def _events_gmtime_offset(cls):
+        events_gmtime_offset = int(_web_now().timestamp()) - 604800
+        if regzbot.is_running_citesting("offline"):
+            events_gmtime_offset = int(_web_now().timestamp()) - 604800 * 52 * 10
+        return events_gmtime_offset
+
+    @classmethod
     def prepare(cls):
         # these are the pages we are going to create
         htmlpages = ("next", "mainline", "stable", "new", "all", "resolved", "inconclusive")
         unhandled_count = len(list(UnhandledEventWeb.get_all()))
+        events_gmtime_offset = cls._events_gmtime_offset()
 
         # gather everything we need
         regressionslist = list()
         eventslist = list()
-        events_gmtime_offset = (
-            int(_web_now().timestamp()) - 604800
-        )
-        if regzbot.is_running_citesting("offline"):
-            events_gmtime_offset = 604800 * 52 * 10
-
         json_data = list()
         for regression in RegressionWeb.get_all():
             json_data.append(cls.regression_to_json(regression))
@@ -1250,3 +1252,19 @@ function timeAgo(provided_date) {
         logger.debug("[webpages] generating")
         cls.publish(cls.prepare())
         logger.debug("[webpages] generated")
+
+
+def dumpall_web():
+    prepared = RegExportWeb.prepare()
+    regressionslist = prepared["regressionslist"]
+    regressionslist.sort(key=lambda x: x.gmtime_activity, reverse=True)
+    categories = RegExportWeb.categorize(regressionslist)
+    mainline = categories.get("mainline", {})
+    if not any(section["entries"] for section in mainline.values()):
+        return
+
+    doc = RegExportWeb.build_compilation(
+        prepared["htmlpages"], prepared["unhandled_count"], mainline, "mainline"
+    )
+    yield yattag.indent(doc.getvalue())
+    yield "\n"

--- a/regzbot/export_web.py
+++ b/regzbot/export_web.py
@@ -17,7 +17,6 @@ from regzbot import PatchKind
 logger = regzbot.logger
 
 
-
 def _web_now():
     mail_now = regzbot._TESTING.get("mail_now")
     if mail_now is not None:
@@ -799,7 +798,7 @@ class RegExportWeb:
             )
 
     @classmethod
-    def createpage_compilation(cls, htmlpages, unhandled_count, categories, pagename):
+    def build_compilation(cls, htmlpages, unhandled_count, categories, pagename):
         tablecolumns = 3
         yattagdoc = yattag.Doc()
         cls.outpage_head(yattagdoc)
@@ -830,8 +829,12 @@ class RegExportWeb:
                                 with yattagdoc.tag("td", style="width: 100px;"):
                                     yattagdoc.text(regressionweb.treename)
             cls.outpage_footer(yattagdoc, unhandled_count)
+        return yattagdoc
 
-            cls.outpage_write(pagename, yattagdoc)
+    @classmethod
+    def createpage_compilation(cls, htmlpages, unhandled_count, categories, pagename):
+        yattagdoc = cls.build_compilation(htmlpages, unhandled_count, categories, pagename)
+        cls.outpage_write(pagename, yattagdoc)
 
     @classmethod
     def create_events(cls, directory, unhandled_count, htmlpages, eventslist):

--- a/regzbot/export_web.py
+++ b/regzbot/export_web.py
@@ -17,6 +17,18 @@ from regzbot import PatchKind
 logger = regzbot.logger
 
 
+
+def _web_now():
+    mail_now = regzbot._TESTING.get("mail_now")
+    if mail_now is not None:
+        return mail_now
+    return regzbot.timendate_now()
+
+
+def _web_days_delta(past):
+    return (_web_now() - datetime.datetime.fromtimestamp(past, datetime.timezone.utc)).days
+
+
 class RegLinkWeb(regzbot.RegLink):
     def __init__(self, *args):
         super().__init__(*args)
@@ -718,7 +730,7 @@ class RegExportWeb:
             yattagdoc.text("[compiled by ")
             with yattagdoc.tag("a", href="https://linux-regtracking.leemhuis.info"):
                 yattagdoc.text("regzbot")
-            currenttime = datetime.datetime.now(datetime.timezone.utc)
+            currenttime = _web_now()
             yattagdoc.text(" on %s (UTC). " % currenttime.strftime("%Y-%m-%d %H:%M:%S"))
 
             yattagdoc.text("Wanna know more about regzbot? Then check out its ")
@@ -999,7 +1011,7 @@ function timeAgo(provided_date) {
         }
 
         for regression in regressionlist:
-            last_activity_days = regzbot.days_delta(regression.gmtime_activity)
+            last_activity_days = _web_days_delta(regression.gmtime_activity)
             if regression.solved_reason == "inconclusive":
                 categories["inconclusive"]["default"]["entries"].append(regression)
             elif regression.gmtime_solved:
@@ -1110,7 +1122,7 @@ function timeAgo(provided_date) {
         regressionslist = list()
         eventslist = list()
         events_gmtime_offset = (
-            int(datetime.datetime.now(datetime.timezone.utc).timestamp()) - 604800
+            int(_web_now().timestamp()) - 604800
         )
         if regzbot.is_running_citesting("offline"):
             events_gmtime_offset = 604800 * 52 * 10
@@ -1187,10 +1199,7 @@ function timeAgo(provided_date) {
         for regression in regressionslist:
             if regression.gmtime_solved:
                 continue
-            filed_days = (
-                datetime.datetime.now(datetime.timezone.utc)
-                - datetime.datetime.fromtimestamp(regression.gmtime_filed, datetime.timezone.utc)
-            ).days
+            filed_days = _web_days_delta(regression.gmtime_filed)
             if filed_days < 7:
                 categories[regression.treename]["entries"].append(regression)
             else:

--- a/regzbot/export_web.py
+++ b/regzbot/export_web.py
@@ -1112,14 +1112,10 @@ function timeAgo(provided_date) {
         }
 
     @classmethod
-    def compile(cls):
-        logger.debug("[webpages] generating")
-
+    def prepare(cls):
         # these are the pages we are going to create
         htmlpages = ("next", "mainline", "stable", "new", "all", "resolved", "inconclusive")
-
-        # handle this page first, as we need something from it anyway
-        unhandled_count = cls.create_unhandled(regzbot.WEBPAGEDIR, htmlpages)
+        unhandled_count = len(list(UnhandledEventWeb.get_all()))
 
         # gather everything we need
         regressionslist = list()
@@ -1167,12 +1163,28 @@ function timeAgo(provided_date) {
                 )
             )
 
-        cls.create_scriptfile_reldate()
-
         eventslist.sort(key=lambda x: x["gmtime"], reverse=True)
+        return {
+            "htmlpages": htmlpages,
+            "unhandled_count": unhandled_count,
+            "regressionslist": regressionslist,
+            "json_data": json_data,
+            "eventslist": eventslist,
+        }
+
+    @classmethod
+    def publish(cls, prepared):
+        htmlpages = prepared["htmlpages"]
+        unhandled_count = prepared["unhandled_count"]
+        regressionslist = prepared["regressionslist"]
+        json_data = prepared["json_data"]
+        eventslist = prepared["eventslist"]
+
+        # handle this page first, as we need something from it anyway
+        cls.create_unhandled(regzbot.WEBPAGEDIR, htmlpages)
+        cls.create_scriptfile_reldate()
         cls.create_events(regzbot.WEBPAGEDIR, unhandled_count, htmlpages, eventslist)
         # we don't need this anymore now that we iterated over all regressions
-        eventslist = events_gmtime_offset = None
 
         # create the page listing all regressions, sorted by date
         regressionslist.sort(key=lambda x: x.gmtime_report, reverse=True)
@@ -1233,4 +1245,8 @@ function timeAgo(provided_date) {
         with open(os.path.join(regzbot.WEBPAGEDIR, "regressions.json"), "w") as jsonfile:
             jsonfile.write(json.dumps(json_data))
 
+    @classmethod
+    def compile(cls):
+        logger.debug("[webpages] generating")
+        cls.publish(cls.prepare())
         logger.debug("[webpages] generated")

--- a/regzbot/testing_offline.py
+++ b/regzbot/testing_offline.py
@@ -22,6 +22,7 @@ import sys
 import git
 import regzbot
 import regzbot.export_csv
+import regzbot.export_mail
 import regzbot.export_web
 import regzbot._repsources._lore
 
@@ -448,6 +449,12 @@ def init_mailsdir(path_tmpmail):
 def init(tmpdir, testdatadir):
     regzbot.set_citesting("offline")
 
+    regzbot._TESTING["mail_now"] = datetime.datetime.fromtimestamp(
+        Emaildir._startdate + 30 * 86400, datetime.timezone.utc
+    )
+    regzbot._TESTING["mail_lastreport_gmtime"] = Emaildir._startdate - 86400
+    regzbot._TESTING["mail_lastreport_msgid"] = "testing-lastreport@example.com"
+
     _, databasedir, gittreesdir, _ = regzbot.basicressources_get_dirs(
         tmpdir=tmpdir, databasedir=os.path.join(tmpdir, "db-offlinetsts")
     )
@@ -474,6 +481,9 @@ def run(resultfilename, tmpdir, testdatadir):
     resultfile = open(resultfilename, "a")
     testfuncprefix = "offltest"
     this = sys.modules[__name__]
+
+    mail_results = []
+    web_results = []
 
     outercount = 0
     while "%s_%s_0" % (testfuncprefix, outercount) in dir(this):
@@ -505,12 +515,21 @@ def run(resultfilename, tmpdir, testdatadir):
                     update_gittrees()
 
             # write results
-            resultfile.write("[%s_%s_%s]\n" % (testfuncprefix, outercount, innercount))
+            name = "%s_%s_%s" % (testfuncprefix, outercount, innercount)
+            resultfile.write("[%s]\n" % name)
             for data in regzbot.export_csv.dumpall_csv():
                 resultfile.write(data)
             resultfile.write("\n")
 
+            mail_results.append("-----BEGIN MAIL %s-----\n" % name)
+            mail_results.extend(regzbot.export_mail.dumpall_mail())
+            mail_results.append("-----END MAIL %s-----\n\n" % name)
+            web_results.append("-----BEGIN WEB %s-----\n" % name)
+            web_results.extend(regzbot.export_web.dumpall_web())
+            web_results.append("-----END WEB %s-----\n\n" % name)
+
             regzbot.export_web.RegExportWeb.compile()
+            regzbot.export_mail.RegExportMailReport.compile(interactive=False)
 
             if instructions and "wait" in instructions:
                 # regzbot.db_commit()
@@ -521,6 +540,15 @@ def run(resultfilename, tmpdir, testdatadir):
         # remove generated mails
         emaildirs_clear()
         outercount += 1
+
+    separator = "=" * 80 + "\n"
+    resultfile.write(separator + "= MAIL REPORTS\n" + separator)
+    for data in mail_results:
+        resultfile.write(data)
+    resultfile.write(separator + "= WEB REPORTS\n" + separator)
+    for data in web_results:
+        resultfile.write(data)
+
     resultfile.close()
     regzbot.db_commit()
     regzbot.db_close()
@@ -1845,3 +1873,31 @@ def offltest_5_2(funcname):
     )
 
     return ["mailchk"]
+
+
+def offltest_6_0(funcname):
+    logger.info("%s: create a regression with link, note, and reply for delete test" % funcname)
+
+    emaildirs["primary"].create_email(funcname, "#regzbot introduced: v1.8..v1.9-rc1")
+
+    subcounter = 1
+    emaildirs["primary"].create_email(
+        "%s_%s" % (funcname, subcounter),
+        "#regzbot relatebrief: https://www.kernel.org/releases.html Some link\n"
+        "#regzbot note: note before delete",
+        replyto=funcname,
+    )
+
+    subcounter += 2
+    emaildirs["primary"].create_email(
+        "%s_%s" % (funcname, subcounter), "a reply to generate activity", replyto=funcname
+    )
+
+    return ["mailchk"]
+
+
+def offltest_6_1(funcname):
+    logger.info("%s: delete the regression created in 6_0" % funcname)
+    for regression in regzbot.RegressionBasic.get_all():
+        regression.delete()
+    return []

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,3 @@
 ruff==0.11.9
 pre-commit==4.2.0
+coverage

--- a/testdata/expected/results-offline.csv
+++ b/testdata/expected/results-offline.csv
@@ -3184,3 +3184,9203 @@ UNHANDLED: 5, https://lore.kernel.org/regressions/regzbot-testing-test_5_2_2@exa
 UNHANDLED: 6, https://lore.kernel.org/regressions/regzbot-testing-test_5_2_3@example.com/, unable to unrelate thread http://lore.kernel.org/somelist/somemsgid/, not related yet, 1546822800, None, test_5_2_3: Lorem ipsum dolor sit amet, None, None, None
 UNHANDLED: 7, https://lore.kernel.org/regressions/regzbot-testing-test_5_2_4@example.com/, unable to unrelate thread http://lore.kernel.org/regressions/some_fake_msgid/, not related yet, 1546909200, None, test_5_2_4: Lorem ipsum dolor sit amet, None, None, None
 
+[offltest_6_0]
+REGRESSION: test_6_0: Lorem ipsum dolor sit amet, v1.8..v1.9-rc1 (None), None, mainline, master, previous: no flags
+INITIAL_REPORT: 1546304400, test_6_0: Lorem ipsum dolor sit amet, Regzbot testingmail, nobody@example.com, https://lore.kernel.org/regressions/regzbot-testing-test_6_0@example.com/
+LINK: Some link, https://www.kernel.org/releases.html, Regzbot testingmail, 1546390800
+ACTIVITY: test_6_0: Lorem ipsum dolor sit amet, Regzbot testingmail, https://lore.kernel.org/regressions/regzbot-testing-test_6_0@example.com/, 1546304400, PatchKind(None)
+ACTIVITY: test_6_0_1: Lorem ipsum dolor sit amet, Regzbot testingmail, https://lore.kernel.org/regressions/regzbot-testing-test_6_0_1@example.com/, 1546390800, PatchKind(None)
+ACTIVITY: test_6_0_3: Lorem ipsum dolor sit amet, Regzbot testingmail, https://lore.kernel.org/regressions/regzbot-testing-test_6_0_3@example.com/, 1546477200, PatchKind(None)
+HISTORY: test_6_0: Lorem ipsum dolor sit amet, 1546304400, Regzbot testingmail, https://lore.kernel.org/regressions/regzbot-testing-test_6_0@example.com/, introduced: v1.8..v1.9-rc1
+HISTORY: test_6_0_1: Lorem ipsum dolor sit amet, 1546390800, Regzbot testingmail, https://lore.kernel.org/regressions/regzbot-testing-test_6_0_1@example.com/, relatebrief: https://www.kernel.org/releases.html Some link
+HISTORY: test_6_0_1: Lorem ipsum dolor sit amet, 1546390800, Regzbot testingmail, https://lore.kernel.org/regressions/regzbot-testing-test_6_0_1@example.com/, note: note before delete
+LATEST: test_6_0_3: Lorem ipsum dolor sit amet, Regzbot testingmail, https://lore.kernel.org/regressions/regzbot-testing-test_6_0_3@example.com/, 1546477200, PatchKind(None)
+
+[offltest_6_1]
+
+================================================================================
+= MAIL REPORTS
+================================================================================
+-----BEGIN MAIL offltest_0_0-----
+-----END MAIL offltest_0_0-----
+
+-----BEGIN MAIL offltest_0_1-----
+-----END MAIL offltest_0_1-----
+
+-----BEGIN MAIL offltest_0_2-----
+-----END MAIL offltest_0_2-----
+
+-----BEGIN MAIL offltest_0_3-----
+-----END MAIL offltest_0_3-----
+
+-----BEGIN MAIL offltest_0_4-----
+-----END MAIL offltest_0_4-----
+
+-----BEGIN MAIL offltest_0_5-----
+-----END MAIL offltest_0_5-----
+
+-----BEGIN MAIL offltest_0_6-----
+-----END MAIL offltest_0_6-----
+
+-----BEGIN MAIL offltest_0_7-----
+-----END MAIL offltest_0_7-----
+
+-----BEGIN MAIL offltest_0_8-----
+-----END MAIL offltest_0_8-----
+
+-----BEGIN MAIL offltest_0_9-----
+-----END MAIL offltest_0_9-----
+
+-----BEGIN MAIL offltest_0_10-----
+-----END MAIL offltest_0_10-----
+
+-----BEGIN MAIL offltest_0_11-----
+-----END MAIL offltest_0_11-----
+
+-----BEGIN MAIL offltest_0_12-----
+-----END MAIL offltest_0_12-----
+
+-----BEGIN MAIL offltest_0_13-----
+
+---
+
+Hi, this is regzbot, the Linux kernel regression tracking bot.
+
+Currently I'm aware of 1 regressions in linux-mainline. Find the
+current status below and the latest on the web:
+
+https://linux-regtracking.leemhuis.info/regzbot/mainline/
+
+Bye bye, hope to see you soon for the next report.
+   Regzbot (on behalf of Thorsten Leemhuis)
+
+
+=======================================================
+on back burner, but with activity since the last report
+=======================================================
+
+
+[ *NEW* ] updated title, set by test_0_10_0
+-------------------------------------------
+https://linux-regtracking.leemhuis.info/regzbot/regression/lore/regzbot-testing-test_0_9_0@example.com/
+https://lore.kernel.org/regressions/regzbot-testing-test_0_9_0@example.com/
+
+By Regzbot testingmail; 19 days ago; 4 activities, latest 13 days ago.
+Introduced in v1.8..v1.9-rc1
+
+Recent activities from: Regzbot testingmail (4)
+
+
+=============
+End of report
+=============
+
+All regressions marked '[ *NEW* ]' were added since the previous report,
+which can be found here:
+https://lore.kernel.org/r/testing-lastreport@example.com
+
+Thanks for your attention, have a nice day!
+
+  Regzbot, your hard working Linux kernel regression tracking robot
+
+
+P.S.: Wanna know more about regzbot or how to use it to track regressions
+for your subsystem? Then check out the getting started guide or the
+reference documentation:
+
+https://gitlab.com/knurd42/regzbot/-/blob/main/docs/getting_started.md
+https://gitlab.com/knurd42/regzbot/-/blob/main/docs/reference.md
+
+The short version: if you see a regression report you want to see
+tracked, just send a reply to the report where you Cc
+regressions@lists.linux.dev with a line like this:
+
+#regzbot introduced: v5.13..v5.14-rc1
+
+If you want to fix a tracked regression, just do what is expected
+anyway: add a 'Link:' tag with the url to the report, e.g.:
+
+Link: https://lore.kernel.org/all/30th.anniversary.repost@klaava.Helsinki.FI/
+-----END MAIL offltest_0_13-----
+
+-----BEGIN MAIL offltest_0_14-----
+-----END MAIL offltest_0_14-----
+
+-----BEGIN MAIL offltest_0_15-----
+-----END MAIL offltest_0_15-----
+
+-----BEGIN MAIL offltest_0_16-----
+-----END MAIL offltest_0_16-----
+
+-----BEGIN MAIL offltest_0_17-----
+-----END MAIL offltest_0_17-----
+
+-----BEGIN MAIL offltest_0_18-----
+-----END MAIL offltest_0_18-----
+
+-----BEGIN MAIL offltest_0_19-----
+-----END MAIL offltest_0_19-----
+
+-----BEGIN MAIL offltest_0_20-----
+-----END MAIL offltest_0_20-----
+
+-----BEGIN MAIL offltest_0_21-----
+-----END MAIL offltest_0_21-----
+
+-----BEGIN MAIL offltest_0_22-----
+-----END MAIL offltest_0_22-----
+
+-----BEGIN MAIL offltest_0_23-----
+-----END MAIL offltest_0_23-----
+
+-----BEGIN MAIL offltest_1_0-----
+-----END MAIL offltest_1_0-----
+
+-----BEGIN MAIL offltest_1_1-----
+-----END MAIL offltest_1_1-----
+
+-----BEGIN MAIL offltest_1_2-----
+-----END MAIL offltest_1_2-----
+
+-----BEGIN MAIL offltest_1_3-----
+-----END MAIL offltest_1_3-----
+
+-----BEGIN MAIL offltest_1_4-----
+-----END MAIL offltest_1_4-----
+
+-----BEGIN MAIL offltest_1_5-----
+-----END MAIL offltest_1_5-----
+
+-----BEGIN MAIL offltest_1_6-----
+-----END MAIL offltest_1_6-----
+
+-----BEGIN MAIL offltest_1_7-----
+
+---
+
+Hi, this is regzbot, the Linux kernel regression tracking bot.
+
+Currently I'm aware of 1 regressions in linux-mainline. Find the
+current status below and the latest on the web:
+
+https://linux-regtracking.leemhuis.info/regzbot/mainline/
+
+Bye bye, hope to see you soon for the next report.
+   Regzbot (on behalf of Thorsten Leemhuis)
+
+
+========================================================
+current cycle (v1.10.. aka v1.11-rc), culprit identified
+========================================================
+
+
+[ *NEW* ] test_1_7: Lorem ipsum dolor sit amet
+----------------------------------------------
+https://linux-regtracking.leemhuis.info/regzbot/regression/lore/regzbot-testing-test_1_7@example.com/
+https://lore.kernel.org/regressions/regzbot-testing-test_1_7@example.com/
+
+By Regzbot testingmail; 25 days ago; 1 activities, latest 25 days ago.
+Introduced in 74cdebb9321b
+
+Recent activities from: Regzbot testingmail (1)
+
+
+=============
+End of report
+=============
+
+All regressions marked '[ *NEW* ]' were added since the previous report,
+which can be found here:
+https://lore.kernel.org/r/testing-lastreport@example.com
+
+Thanks for your attention, have a nice day!
+
+  Regzbot, your hard working Linux kernel regression tracking robot
+
+
+P.S.: Wanna know more about regzbot or how to use it to track regressions
+for your subsystem? Then check out the getting started guide or the
+reference documentation:
+
+https://gitlab.com/knurd42/regzbot/-/blob/main/docs/getting_started.md
+https://gitlab.com/knurd42/regzbot/-/blob/main/docs/reference.md
+
+The short version: if you see a regression report you want to see
+tracked, just send a reply to the report where you Cc
+regressions@lists.linux.dev with a line like this:
+
+#regzbot introduced: v5.13..v5.14-rc1
+
+If you want to fix a tracked regression, just do what is expected
+anyway: add a 'Link:' tag with the url to the report, e.g.:
+
+Link: https://lore.kernel.org/all/30th.anniversary.repost@klaava.Helsinki.FI/
+-----END MAIL offltest_1_7-----
+
+-----BEGIN MAIL offltest_1_8-----
+
+---
+
+Hi, this is regzbot, the Linux kernel regression tracking bot.
+
+Currently I'm aware of 1 regressions in linux-mainline. Find the
+current status below and the latest on the web:
+
+https://linux-regtracking.leemhuis.info/regzbot/mainline/
+
+Bye bye, hope to see you soon for the next report.
+   Regzbot (on behalf of Thorsten Leemhuis)
+
+
+========================================================
+current cycle (v1.10.. aka v1.11-rc), culprit identified
+========================================================
+
+
+[ *NEW* ] test_1_7: Lorem ipsum dolor sit amet
+----------------------------------------------
+https://linux-regtracking.leemhuis.info/regzbot/regression/lore/regzbot-testing-test_1_7@example.com/
+https://lore.kernel.org/regressions/regzbot-testing-test_1_7@example.com/
+
+By Regzbot testingmail; 25 days ago; 1 activities, latest 25 days ago.
+Introduced in 74cdebb9321b
+
+Recent activities from: Regzbot testingmail (1)
+
+
+=============
+End of report
+=============
+
+All regressions marked '[ *NEW* ]' were added since the previous report,
+which can be found here:
+https://lore.kernel.org/r/testing-lastreport@example.com
+
+Thanks for your attention, have a nice day!
+
+  Regzbot, your hard working Linux kernel regression tracking robot
+
+
+P.S.: Wanna know more about regzbot or how to use it to track regressions
+for your subsystem? Then check out the getting started guide or the
+reference documentation:
+
+https://gitlab.com/knurd42/regzbot/-/blob/main/docs/getting_started.md
+https://gitlab.com/knurd42/regzbot/-/blob/main/docs/reference.md
+
+The short version: if you see a regression report you want to see
+tracked, just send a reply to the report where you Cc
+regressions@lists.linux.dev with a line like this:
+
+#regzbot introduced: v5.13..v5.14-rc1
+
+If you want to fix a tracked regression, just do what is expected
+anyway: add a 'Link:' tag with the url to the report, e.g.:
+
+Link: https://lore.kernel.org/all/30th.anniversary.repost@klaava.Helsinki.FI/
+-----END MAIL offltest_1_8-----
+
+-----BEGIN MAIL offltest_1_9-----
+
+---
+
+Hi, this is regzbot, the Linux kernel regression tracking bot.
+
+Currently I'm aware of 1 regressions in linux-mainline. Find the
+current status below and the latest on the web:
+
+https://linux-regtracking.leemhuis.info/regzbot/mainline/
+
+Bye bye, hope to see you soon for the next report.
+   Regzbot (on behalf of Thorsten Leemhuis)
+
+
+========================================================
+current cycle (v1.10.. aka v1.11-rc), culprit identified
+========================================================
+
+
+[ *NEW* ] test_1_7: Lorem ipsum dolor sit amet
+----------------------------------------------
+https://linux-regtracking.leemhuis.info/regzbot/regression/lore/regzbot-testing-test_1_7@example.com/
+https://lore.kernel.org/regressions/regzbot-testing-test_1_7@example.com/
+
+By Regzbot testingmail; 25 days ago; 1 activities, latest 25 days ago.
+Introduced in 74cdebb9321b
+
+Recent activities from: Regzbot testingmail (1)
+
+
+=============
+End of report
+=============
+
+All regressions marked '[ *NEW* ]' were added since the previous report,
+which can be found here:
+https://lore.kernel.org/r/testing-lastreport@example.com
+
+Thanks for your attention, have a nice day!
+
+  Regzbot, your hard working Linux kernel regression tracking robot
+
+
+P.S.: Wanna know more about regzbot or how to use it to track regressions
+for your subsystem? Then check out the getting started guide or the
+reference documentation:
+
+https://gitlab.com/knurd42/regzbot/-/blob/main/docs/getting_started.md
+https://gitlab.com/knurd42/regzbot/-/blob/main/docs/reference.md
+
+The short version: if you see a regression report you want to see
+tracked, just send a reply to the report where you Cc
+regressions@lists.linux.dev with a line like this:
+
+#regzbot introduced: v5.13..v5.14-rc1
+
+If you want to fix a tracked regression, just do what is expected
+anyway: add a 'Link:' tag with the url to the report, e.g.:
+
+Link: https://lore.kernel.org/all/30th.anniversary.repost@klaava.Helsinki.FI/
+-----END MAIL offltest_1_9-----
+
+-----BEGIN MAIL offltest_1_10-----
+
+---
+
+Hi, this is regzbot, the Linux kernel regression tracking bot.
+
+Currently I'm aware of 1 regressions in linux-mainline. Find the
+current status below and the latest on the web:
+
+https://linux-regtracking.leemhuis.info/regzbot/mainline/
+
+Bye bye, hope to see you soon for the next report.
+   Regzbot (on behalf of Thorsten Leemhuis)
+
+
+========================================================
+current cycle (v1.10.. aka v1.11-rc), culprit identified
+========================================================
+
+
+[ *NEW* ] test_1_7: Lorem ipsum dolor sit amet
+----------------------------------------------
+https://linux-regtracking.leemhuis.info/regzbot/regression/lore/regzbot-testing-test_1_7@example.com/
+https://lore.kernel.org/regressions/regzbot-testing-test_1_7@example.com/
+
+By Regzbot testingmail; 25 days ago; 1 activities, latest 25 days ago.
+Introduced in 74cdebb9321b
+
+Recent activities from: Regzbot testingmail (1)
+
+
+=============
+End of report
+=============
+
+All regressions marked '[ *NEW* ]' were added since the previous report,
+which can be found here:
+https://lore.kernel.org/r/testing-lastreport@example.com
+
+Thanks for your attention, have a nice day!
+
+  Regzbot, your hard working Linux kernel regression tracking robot
+
+
+P.S.: Wanna know more about regzbot or how to use it to track regressions
+for your subsystem? Then check out the getting started guide or the
+reference documentation:
+
+https://gitlab.com/knurd42/regzbot/-/blob/main/docs/getting_started.md
+https://gitlab.com/knurd42/regzbot/-/blob/main/docs/reference.md
+
+The short version: if you see a regression report you want to see
+tracked, just send a reply to the report where you Cc
+regressions@lists.linux.dev with a line like this:
+
+#regzbot introduced: v5.13..v5.14-rc1
+
+If you want to fix a tracked regression, just do what is expected
+anyway: add a 'Link:' tag with the url to the report, e.g.:
+
+Link: https://lore.kernel.org/all/30th.anniversary.repost@klaava.Helsinki.FI/
+-----END MAIL offltest_1_10-----
+
+-----BEGIN MAIL offltest_1_11-----
+
+---
+
+Hi, this is regzbot, the Linux kernel regression tracking bot.
+
+Currently I'm aware of 1 regressions in linux-mainline. Find the
+current status below and the latest on the web:
+
+https://linux-regtracking.leemhuis.info/regzbot/mainline/
+
+Bye bye, hope to see you soon for the next report.
+   Regzbot (on behalf of Thorsten Leemhuis)
+
+
+========================================================
+current cycle (v1.10.. aka v1.11-rc), culprit identified
+========================================================
+
+
+[ *NEW* ] test_1_7: Lorem ipsum dolor sit amet
+----------------------------------------------
+https://linux-regtracking.leemhuis.info/regzbot/regression/lore/regzbot-testing-test_1_7@example.com/
+https://lore.kernel.org/regressions/regzbot-testing-test_1_7@example.com/
+
+By Regzbot testingmail; 25 days ago; 1 activities, latest 25 days ago.
+Introduced in 74cdebb9321b
+
+Recent activities from: Regzbot testingmail (1)
+
+
+=============
+End of report
+=============
+
+All regressions marked '[ *NEW* ]' were added since the previous report,
+which can be found here:
+https://lore.kernel.org/r/testing-lastreport@example.com
+
+Thanks for your attention, have a nice day!
+
+  Regzbot, your hard working Linux kernel regression tracking robot
+
+
+P.S.: Wanna know more about regzbot or how to use it to track regressions
+for your subsystem? Then check out the getting started guide or the
+reference documentation:
+
+https://gitlab.com/knurd42/regzbot/-/blob/main/docs/getting_started.md
+https://gitlab.com/knurd42/regzbot/-/blob/main/docs/reference.md
+
+The short version: if you see a regression report you want to see
+tracked, just send a reply to the report where you Cc
+regressions@lists.linux.dev with a line like this:
+
+#regzbot introduced: v5.13..v5.14-rc1
+
+If you want to fix a tracked regression, just do what is expected
+anyway: add a 'Link:' tag with the url to the report, e.g.:
+
+Link: https://lore.kernel.org/all/30th.anniversary.repost@klaava.Helsinki.FI/
+-----END MAIL offltest_1_11-----
+
+-----BEGIN MAIL offltest_1_12-----
+
+---
+
+Hi, this is regzbot, the Linux kernel regression tracking bot.
+
+Currently I'm aware of 1 regressions in linux-mainline. Find the
+current status below and the latest on the web:
+
+https://linux-regtracking.leemhuis.info/regzbot/mainline/
+
+Bye bye, hope to see you soon for the next report.
+   Regzbot (on behalf of Thorsten Leemhuis)
+
+
+========================================================
+current cycle (v1.10.. aka v1.11-rc), culprit identified
+========================================================
+
+
+[ *NEW* ] test_1_7: Lorem ipsum dolor sit amet
+----------------------------------------------
+https://linux-regtracking.leemhuis.info/regzbot/regression/lore/regzbot-testing-test_1_7@example.com/
+https://lore.kernel.org/regressions/regzbot-testing-test_1_7@example.com/
+
+By Regzbot testingmail; 25 days ago; 1 activities, latest 25 days ago.
+Introduced in 74cdebb9321b
+
+Recent activities from: Regzbot testingmail (1)
+
+
+=============
+End of report
+=============
+
+All regressions marked '[ *NEW* ]' were added since the previous report,
+which can be found here:
+https://lore.kernel.org/r/testing-lastreport@example.com
+
+Thanks for your attention, have a nice day!
+
+  Regzbot, your hard working Linux kernel regression tracking robot
+
+
+P.S.: Wanna know more about regzbot or how to use it to track regressions
+for your subsystem? Then check out the getting started guide or the
+reference documentation:
+
+https://gitlab.com/knurd42/regzbot/-/blob/main/docs/getting_started.md
+https://gitlab.com/knurd42/regzbot/-/blob/main/docs/reference.md
+
+The short version: if you see a regression report you want to see
+tracked, just send a reply to the report where you Cc
+regressions@lists.linux.dev with a line like this:
+
+#regzbot introduced: v5.13..v5.14-rc1
+
+If you want to fix a tracked regression, just do what is expected
+anyway: add a 'Link:' tag with the url to the report, e.g.:
+
+Link: https://lore.kernel.org/all/30th.anniversary.repost@klaava.Helsinki.FI/
+-----END MAIL offltest_1_12-----
+
+-----BEGIN MAIL offltest_2_0-----
+-----END MAIL offltest_2_0-----
+
+-----BEGIN MAIL offltest_2_1-----
+-----END MAIL offltest_2_1-----
+
+-----BEGIN MAIL offltest_2_2-----
+-----END MAIL offltest_2_2-----
+
+-----BEGIN MAIL offltest_2_3-----
+-----END MAIL offltest_2_3-----
+
+-----BEGIN MAIL offltest_2_4-----
+-----END MAIL offltest_2_4-----
+
+-----BEGIN MAIL offltest_2_5-----
+-----END MAIL offltest_2_5-----
+
+-----BEGIN MAIL offltest_2_6-----
+-----END MAIL offltest_2_6-----
+
+-----BEGIN MAIL offltest_2_7-----
+-----END MAIL offltest_2_7-----
+
+-----BEGIN MAIL offltest_2_8-----
+-----END MAIL offltest_2_8-----
+
+-----BEGIN MAIL offltest_2_9-----
+-----END MAIL offltest_2_9-----
+
+-----BEGIN MAIL offltest_2_10-----
+-----END MAIL offltest_2_10-----
+
+-----BEGIN MAIL offltest_2_11-----
+-----END MAIL offltest_2_11-----
+
+-----BEGIN MAIL offltest_2_12-----
+-----END MAIL offltest_2_12-----
+
+-----BEGIN MAIL offltest_2_13-----
+
+---
+
+Hi, this is regzbot, the Linux kernel regression tracking bot.
+
+Currently I'm aware of 1 regressions in linux-mainline. Find the
+current status below and the latest on the web:
+
+https://linux-regtracking.leemhuis.info/regzbot/mainline/
+
+Bye bye, hope to see you soon for the next report.
+   Regzbot (on behalf of Thorsten Leemhuis)
+
+
+========================================================
+current cycle (v1.10.. aka v1.11-rc), culprit identified
+========================================================
+
+
+[ *NEW* ] new title set via a monitored thread
+----------------------------------------------
+https://linux-regtracking.leemhuis.info/regzbot/regression/lore/regzbot-testing-test_2_0@example.com/
+https://lore.kernel.org/regressions/regzbot-testing-test_2_0@example.com/
+
+By Regzbot testingmail; 30 days ago; 11 activities, latest 13 days ago.
+Introduced in 23bde5c338c7
+
+Recent activities from: Regzbot testingmail (11)
+
+3 patch postings are associated with this regression, the latest is this:
+* test_2_12_3: add a mail with a simple patch
+  https://lore.kernel.org/regressions/regzbot-testing-test_2_12_3@example.com/
+  14 days ago, by Regzbot testingmail
+
+Noteworthy links:
+* test_2_9: refer to this regression on another mainling list [implicit due to Link/Closes tag]
+  https://lore.kernel.org/lkml/regzbot-testing-test_2_9@example.com/
+  20 days ago, by Regzbot testingmail; thread monitored.
+
+
+=============
+End of report
+=============
+
+All regressions marked '[ *NEW* ]' were added since the previous report,
+which can be found here:
+https://lore.kernel.org/r/testing-lastreport@example.com
+
+Thanks for your attention, have a nice day!
+
+  Regzbot, your hard working Linux kernel regression tracking robot
+
+
+P.S.: Wanna know more about regzbot or how to use it to track regressions
+for your subsystem? Then check out the getting started guide or the
+reference documentation:
+
+https://gitlab.com/knurd42/regzbot/-/blob/main/docs/getting_started.md
+https://gitlab.com/knurd42/regzbot/-/blob/main/docs/reference.md
+
+The short version: if you see a regression report you want to see
+tracked, just send a reply to the report where you Cc
+regressions@lists.linux.dev with a line like this:
+
+#regzbot introduced: v5.13..v5.14-rc1
+
+If you want to fix a tracked regression, just do what is expected
+anyway: add a 'Link:' tag with the url to the report, e.g.:
+
+Link: https://lore.kernel.org/all/30th.anniversary.repost@klaava.Helsinki.FI/
+-----END MAIL offltest_2_13-----
+
+-----BEGIN MAIL offltest_2_14-----
+
+---
+
+Hi, this is regzbot, the Linux kernel regression tracking bot.
+
+Currently I'm aware of 1 regressions in linux-mainline. Find the
+current status below and the latest on the web:
+
+https://linux-regtracking.leemhuis.info/regzbot/mainline/
+
+Bye bye, hope to see you soon for the next report.
+   Regzbot (on behalf of Thorsten Leemhuis)
+
+
+========================================================
+current cycle (v1.10.. aka v1.11-rc), culprit identified
+========================================================
+
+
+[ *NEW* ] new title set via a monitored thread
+----------------------------------------------
+https://linux-regtracking.leemhuis.info/regzbot/regression/lore/regzbot-testing-test_2_0@example.com/
+https://lore.kernel.org/regressions/regzbot-testing-test_2_0@example.com/
+
+By Regzbot testingmail; 30 days ago; 11 activities, latest 13 days ago.
+Introduced in 23bde5c338c7
+
+Recent activities from: Regzbot testingmail (11)
+
+3 patch postings are associated with this regression, the latest is this:
+* test_2_12_3: add a mail with a simple patch
+  https://lore.kernel.org/regressions/regzbot-testing-test_2_12_3@example.com/
+  14 days ago, by Regzbot testingmail
+
+Noteworthy links:
+* test_2_9: refer to this regression on another mainling list [implicit due to Link/Closes tag]
+  https://lore.kernel.org/lkml/regzbot-testing-test_2_9@example.com/
+  20 days ago, by Regzbot testingmail; thread monitored.
+
+
+=============
+End of report
+=============
+
+All regressions marked '[ *NEW* ]' were added since the previous report,
+which can be found here:
+https://lore.kernel.org/r/testing-lastreport@example.com
+
+Thanks for your attention, have a nice day!
+
+  Regzbot, your hard working Linux kernel regression tracking robot
+
+
+P.S.: Wanna know more about regzbot or how to use it to track regressions
+for your subsystem? Then check out the getting started guide or the
+reference documentation:
+
+https://gitlab.com/knurd42/regzbot/-/blob/main/docs/getting_started.md
+https://gitlab.com/knurd42/regzbot/-/blob/main/docs/reference.md
+
+The short version: if you see a regression report you want to see
+tracked, just send a reply to the report where you Cc
+regressions@lists.linux.dev with a line like this:
+
+#regzbot introduced: v5.13..v5.14-rc1
+
+If you want to fix a tracked regression, just do what is expected
+anyway: add a 'Link:' tag with the url to the report, e.g.:
+
+Link: https://lore.kernel.org/all/30th.anniversary.repost@klaava.Helsinki.FI/
+-----END MAIL offltest_2_14-----
+
+-----BEGIN MAIL offltest_2_15-----
+
+---
+
+Hi, this is regzbot, the Linux kernel regression tracking bot.
+
+Currently I'm aware of 1 regressions in linux-mainline. Find the
+current status below and the latest on the web:
+
+https://linux-regtracking.leemhuis.info/regzbot/mainline/
+
+Bye bye, hope to see you soon for the next report.
+   Regzbot (on behalf of Thorsten Leemhuis)
+
+
+========================================================
+current cycle (v1.10.. aka v1.11-rc), culprit identified
+========================================================
+
+
+[ *NEW* ] new title set via a monitored thread
+----------------------------------------------
+https://linux-regtracking.leemhuis.info/regzbot/regression/lore/regzbot-testing-test_2_0@example.com/
+https://lore.kernel.org/regressions/regzbot-testing-test_2_0@example.com/
+https://lore.kernel.org/regressions/regzbot-testing-test_2_14_0@example.com/
+
+By Regzbot testingmail and Regzbot testingmail; 30 days ago; 12 activities, latest 8 days ago.
+Introduced in 23bde5c338c7
+
+Recent activities from: Regzbot testingmail (12)
+
+3 patch postings are associated with this regression, the latest is this:
+* test_2_12_3: add a mail with a simple patch
+  https://lore.kernel.org/regressions/regzbot-testing-test_2_12_3@example.com/
+  14 days ago, by Regzbot testingmail
+
+Noteworthy links:
+* test_2_9: refer to this regression on another mainling list [implicit due to Link/Closes tag]
+  https://lore.kernel.org/lkml/regzbot-testing-test_2_9@example.com/
+  20 days ago, by Regzbot testingmail; thread monitored.
+
+
+=============
+End of report
+=============
+
+All regressions marked '[ *NEW* ]' were added since the previous report,
+which can be found here:
+https://lore.kernel.org/r/testing-lastreport@example.com
+
+Thanks for your attention, have a nice day!
+
+  Regzbot, your hard working Linux kernel regression tracking robot
+
+
+P.S.: Wanna know more about regzbot or how to use it to track regressions
+for your subsystem? Then check out the getting started guide or the
+reference documentation:
+
+https://gitlab.com/knurd42/regzbot/-/blob/main/docs/getting_started.md
+https://gitlab.com/knurd42/regzbot/-/blob/main/docs/reference.md
+
+The short version: if you see a regression report you want to see
+tracked, just send a reply to the report where you Cc
+regressions@lists.linux.dev with a line like this:
+
+#regzbot introduced: v5.13..v5.14-rc1
+
+If you want to fix a tracked regression, just do what is expected
+anyway: add a 'Link:' tag with the url to the report, e.g.:
+
+Link: https://lore.kernel.org/all/30th.anniversary.repost@klaava.Helsinki.FI/
+-----END MAIL offltest_2_15-----
+
+-----BEGIN MAIL offltest_2_16-----
+
+---
+
+Hi, this is regzbot, the Linux kernel regression tracking bot.
+
+Currently I'm aware of 1 regressions in linux-mainline. Find the
+current status below and the latest on the web:
+
+https://linux-regtracking.leemhuis.info/regzbot/mainline/
+
+Bye bye, hope to see you soon for the next report.
+   Regzbot (on behalf of Thorsten Leemhuis)
+
+
+========================================================
+current cycle (v1.10.. aka v1.11-rc), culprit identified
+========================================================
+
+
+[ *NEW* ] new title set via a monitored thread
+----------------------------------------------
+https://linux-regtracking.leemhuis.info/regzbot/regression/lore/regzbot-testing-test_2_0@example.com/
+https://lore.kernel.org/regressions/regzbot-testing-test_2_0@example.com/
+https://lore.kernel.org/regressions/regzbot-testing-test_2_14_0@example.com/
+
+By Regzbot testingmail and Regzbot testingmail; 30 days ago; 12 activities, latest 8 days ago.
+Introduced in 23bde5c338c7
+
+Recent activities from: Regzbot testingmail (12)
+
+3 patch postings are associated with this regression, the latest is this:
+* test_2_12_3: add a mail with a simple patch
+  https://lore.kernel.org/regressions/regzbot-testing-test_2_12_3@example.com/
+  14 days ago, by Regzbot testingmail
+
+Noteworthy links:
+* test_2_9: refer to this regression on another mainling list [implicit due to Link/Closes tag]
+  https://lore.kernel.org/lkml/regzbot-testing-test_2_9@example.com/
+  20 days ago, by Regzbot testingmail; thread monitored.
+
+
+=============
+End of report
+=============
+
+All regressions marked '[ *NEW* ]' were added since the previous report,
+which can be found here:
+https://lore.kernel.org/r/testing-lastreport@example.com
+
+Thanks for your attention, have a nice day!
+
+  Regzbot, your hard working Linux kernel regression tracking robot
+
+
+P.S.: Wanna know more about regzbot or how to use it to track regressions
+for your subsystem? Then check out the getting started guide or the
+reference documentation:
+
+https://gitlab.com/knurd42/regzbot/-/blob/main/docs/getting_started.md
+https://gitlab.com/knurd42/regzbot/-/blob/main/docs/reference.md
+
+The short version: if you see a regression report you want to see
+tracked, just send a reply to the report where you Cc
+regressions@lists.linux.dev with a line like this:
+
+#regzbot introduced: v5.13..v5.14-rc1
+
+If you want to fix a tracked regression, just do what is expected
+anyway: add a 'Link:' tag with the url to the report, e.g.:
+
+Link: https://lore.kernel.org/all/30th.anniversary.repost@klaava.Helsinki.FI/
+-----END MAIL offltest_2_16-----
+
+-----BEGIN MAIL offltest_3_0-----
+-----END MAIL offltest_3_0-----
+
+-----BEGIN MAIL offltest_3_1-----
+-----END MAIL offltest_3_1-----
+
+-----BEGIN MAIL offltest_3_2-----
+-----END MAIL offltest_3_2-----
+
+-----BEGIN MAIL offltest_3_3-----
+-----END MAIL offltest_3_3-----
+
+-----BEGIN MAIL offltest_3_4-----
+-----END MAIL offltest_3_4-----
+
+-----BEGIN MAIL offltest_3_5-----
+-----END MAIL offltest_3_5-----
+
+-----BEGIN MAIL offltest_4_0-----
+
+---
+
+Hi, this is regzbot, the Linux kernel regression tracking bot.
+
+Currently I'm aware of 2 regressions in linux-mainline. Find the
+current status below and the latest on the web:
+
+https://linux-regtracking.leemhuis.info/regzbot/mainline/
+
+Bye bye, hope to see you soon for the next report.
+   Regzbot (on behalf of Thorsten Leemhuis)
+
+
+========================================================
+current cycle (v1.10.. aka v1.11-rc), culprit identified
+========================================================
+
+
+[ *NEW* ] test_4_0_1: Lorem ipsum dolor sit amet
+------------------------------------------------
+https://linux-regtracking.leemhuis.info/regzbot/regression/lore/regzbot-testing-test_4_0_1@example.com/
+https://lore.kernel.org/regressions/regzbot-testing-test_4_0_1@example.com/
+
+By Regzbot testingmail; 29 days ago; 1 activities, latest 29 days ago.
+Introduced in 23bde5c338c7
+
+Recent activities from: Regzbot testingmail (1)
+
+
+=====================================================
+current cycle (v1.10.. aka v1.11-rc), unknown culprit
+=====================================================
+
+
+[ *NEW* ] test_4_0_0: Lorem ipsum dolor sit amet
+------------------------------------------------
+https://linux-regtracking.leemhuis.info/regzbot/regression/lore/regzbot-testing-test_4_0_0@example.com/
+https://lore.kernel.org/regressions/regzbot-testing-test_4_0_0@example.com/
+
+By Regzbot testingmail; 30 days ago; 1 activities, latest 30 days ago.
+Introduced in v1.10..v1.11-rc1
+
+Recent activities from: Regzbot testingmail (1)
+
+
+=============
+End of report
+=============
+
+All regressions marked '[ *NEW* ]' were added since the previous report,
+which can be found here:
+https://lore.kernel.org/r/testing-lastreport@example.com
+
+Thanks for your attention, have a nice day!
+
+  Regzbot, your hard working Linux kernel regression tracking robot
+
+
+P.S.: Wanna know more about regzbot or how to use it to track regressions
+for your subsystem? Then check out the getting started guide or the
+reference documentation:
+
+https://gitlab.com/knurd42/regzbot/-/blob/main/docs/getting_started.md
+https://gitlab.com/knurd42/regzbot/-/blob/main/docs/reference.md
+
+The short version: if you see a regression report you want to see
+tracked, just send a reply to the report where you Cc
+regressions@lists.linux.dev with a line like this:
+
+#regzbot introduced: v5.13..v5.14-rc1
+
+If you want to fix a tracked regression, just do what is expected
+anyway: add a 'Link:' tag with the url to the report, e.g.:
+
+Link: https://lore.kernel.org/all/30th.anniversary.repost@klaava.Helsinki.FI/
+-----END MAIL offltest_4_0-----
+
+-----BEGIN MAIL offltest_4_1-----
+
+---
+
+Hi, this is regzbot, the Linux kernel regression tracking bot.
+
+Currently I'm aware of 2 regressions in linux-mainline. Find the
+current status below and the latest on the web:
+
+https://linux-regtracking.leemhuis.info/regzbot/mainline/
+
+Bye bye, hope to see you soon for the next report.
+   Regzbot (on behalf of Thorsten Leemhuis)
+
+
+========================================================
+current cycle (v1.10.. aka v1.11-rc), culprit identified
+========================================================
+
+
+[ *NEW* ] test_4_0_1: Lorem ipsum dolor sit amet
+------------------------------------------------
+https://linux-regtracking.leemhuis.info/regzbot/regression/lore/regzbot-testing-test_4_0_1@example.com/
+https://lore.kernel.org/regressions/regzbot-testing-test_4_0_1@example.com/
+
+By Regzbot testingmail; 29 days ago; 1 activities, latest 29 days ago.
+Introduced in 23bde5c338c7
+
+Recent activities from: Regzbot testingmail (1)
+
+
+=====================================================
+current cycle (v1.10.. aka v1.11-rc), unknown culprit
+=====================================================
+
+
+[ *NEW* ] test_4_0_0: Lorem ipsum dolor sit amet
+------------------------------------------------
+https://linux-regtracking.leemhuis.info/regzbot/regression/lore/regzbot-testing-test_4_0_0@example.com/
+https://lore.kernel.org/regressions/regzbot-testing-test_4_0_0@example.com/
+
+By Regzbot testingmail; 30 days ago; 1 activities, latest 30 days ago.
+Introduced in v1.10..v1.11-rc1
+
+Recent activities from: Regzbot testingmail (1)
+
+
+=============
+End of report
+=============
+
+All regressions marked '[ *NEW* ]' were added since the previous report,
+which can be found here:
+https://lore.kernel.org/r/testing-lastreport@example.com
+
+Thanks for your attention, have a nice day!
+
+  Regzbot, your hard working Linux kernel regression tracking robot
+
+
+P.S.: Wanna know more about regzbot or how to use it to track regressions
+for your subsystem? Then check out the getting started guide or the
+reference documentation:
+
+https://gitlab.com/knurd42/regzbot/-/blob/main/docs/getting_started.md
+https://gitlab.com/knurd42/regzbot/-/blob/main/docs/reference.md
+
+The short version: if you see a regression report you want to see
+tracked, just send a reply to the report where you Cc
+regressions@lists.linux.dev with a line like this:
+
+#regzbot introduced: v5.13..v5.14-rc1
+
+If you want to fix a tracked regression, just do what is expected
+anyway: add a 'Link:' tag with the url to the report, e.g.:
+
+Link: https://lore.kernel.org/all/30th.anniversary.repost@klaava.Helsinki.FI/
+-----END MAIL offltest_4_1-----
+
+-----BEGIN MAIL offltest_4_2-----
+
+---
+
+Hi, this is regzbot, the Linux kernel regression tracking bot.
+
+Currently I'm aware of 2 regressions in linux-mainline. Find the
+current status below and the latest on the web:
+
+https://linux-regtracking.leemhuis.info/regzbot/mainline/
+
+Bye bye, hope to see you soon for the next report.
+   Regzbot (on behalf of Thorsten Leemhuis)
+
+
+========================================================
+current cycle (v1.10.. aka v1.11-rc), culprit identified
+========================================================
+
+
+[ *NEW* ] test_4_0_1: Lorem ipsum dolor sit amet
+------------------------------------------------
+https://linux-regtracking.leemhuis.info/regzbot/regression/lore/regzbot-testing-test_4_0_1@example.com/
+https://lore.kernel.org/regressions/regzbot-testing-test_4_0_1@example.com/
+
+By Regzbot testingmail; 29 days ago; 1 activities, latest 29 days ago.
+Introduced in 23bde5c338c7
+
+Recent activities from: Regzbot testingmail (1)
+
+
+=====================================================
+current cycle (v1.10.. aka v1.11-rc), unknown culprit
+=====================================================
+
+
+[ *NEW* ] test_4_0_0: Lorem ipsum dolor sit amet
+------------------------------------------------
+https://linux-regtracking.leemhuis.info/regzbot/regression/lore/regzbot-testing-test_4_0_0@example.com/
+https://lore.kernel.org/regressions/regzbot-testing-test_4_0_0@example.com/
+
+By Regzbot testingmail; 30 days ago; 1 activities, latest 30 days ago.
+Introduced in v1.10..v1.11-rc1
+
+Recent activities from: Regzbot testingmail (1)
+
+
+=============
+End of report
+=============
+
+All regressions marked '[ *NEW* ]' were added since the previous report,
+which can be found here:
+https://lore.kernel.org/r/testing-lastreport@example.com
+
+Thanks for your attention, have a nice day!
+
+  Regzbot, your hard working Linux kernel regression tracking robot
+
+
+P.S.: Wanna know more about regzbot or how to use it to track regressions
+for your subsystem? Then check out the getting started guide or the
+reference documentation:
+
+https://gitlab.com/knurd42/regzbot/-/blob/main/docs/getting_started.md
+https://gitlab.com/knurd42/regzbot/-/blob/main/docs/reference.md
+
+The short version: if you see a regression report you want to see
+tracked, just send a reply to the report where you Cc
+regressions@lists.linux.dev with a line like this:
+
+#regzbot introduced: v5.13..v5.14-rc1
+
+If you want to fix a tracked regression, just do what is expected
+anyway: add a 'Link:' tag with the url to the report, e.g.:
+
+Link: https://lore.kernel.org/all/30th.anniversary.repost@klaava.Helsinki.FI/
+-----END MAIL offltest_4_2-----
+
+-----BEGIN MAIL offltest_4_3-----
+
+---
+
+Hi, this is regzbot, the Linux kernel regression tracking bot.
+
+Currently I'm aware of 2 regressions in linux-mainline. Find the
+current status below and the latest on the web:
+
+https://linux-regtracking.leemhuis.info/regzbot/mainline/
+
+Bye bye, hope to see you soon for the next report.
+   Regzbot (on behalf of Thorsten Leemhuis)
+
+
+========================================================
+current cycle (v1.10.. aka v1.11-rc), culprit identified
+========================================================
+
+
+[ *NEW* ] test_4_0_1: Lorem ipsum dolor sit amet
+------------------------------------------------
+https://linux-regtracking.leemhuis.info/regzbot/regression/lore/regzbot-testing-test_4_0_1@example.com/
+https://lore.kernel.org/regressions/regzbot-testing-test_4_0_1@example.com/
+
+By Regzbot testingmail; 29 days ago; 1 activities, latest 29 days ago.
+Introduced in 23bde5c338c7
+
+Recent activities from: Regzbot testingmail (1)
+
+
+=====================================================
+current cycle (v1.10.. aka v1.11-rc), unknown culprit
+=====================================================
+
+
+[ *NEW* ] test_4_0_0: Lorem ipsum dolor sit amet
+------------------------------------------------
+https://linux-regtracking.leemhuis.info/regzbot/regression/lore/regzbot-testing-test_4_0_0@example.com/
+https://lore.kernel.org/regressions/regzbot-testing-test_4_0_0@example.com/
+
+By Regzbot testingmail; 30 days ago; 1 activities, latest 30 days ago.
+Introduced in v1.10..v1.11-rc1
+
+Recent activities from: Regzbot testingmail (1)
+
+
+=============
+End of report
+=============
+
+All regressions marked '[ *NEW* ]' were added since the previous report,
+which can be found here:
+https://lore.kernel.org/r/testing-lastreport@example.com
+
+Thanks for your attention, have a nice day!
+
+  Regzbot, your hard working Linux kernel regression tracking robot
+
+
+P.S.: Wanna know more about regzbot or how to use it to track regressions
+for your subsystem? Then check out the getting started guide or the
+reference documentation:
+
+https://gitlab.com/knurd42/regzbot/-/blob/main/docs/getting_started.md
+https://gitlab.com/knurd42/regzbot/-/blob/main/docs/reference.md
+
+The short version: if you see a regression report you want to see
+tracked, just send a reply to the report where you Cc
+regressions@lists.linux.dev with a line like this:
+
+#regzbot introduced: v5.13..v5.14-rc1
+
+If you want to fix a tracked regression, just do what is expected
+anyway: add a 'Link:' tag with the url to the report, e.g.:
+
+Link: https://lore.kernel.org/all/30th.anniversary.repost@klaava.Helsinki.FI/
+-----END MAIL offltest_4_3-----
+
+-----BEGIN MAIL offltest_4_4-----
+
+---
+
+Hi, this is regzbot, the Linux kernel regression tracking bot.
+
+Currently I'm aware of 5 regressions in linux-mainline. Find the
+current status below and the latest on the web:
+
+https://linux-regtracking.leemhuis.info/regzbot/mainline/
+
+Bye bye, hope to see you soon for the next report.
+   Regzbot (on behalf of Thorsten Leemhuis)
+
+
+========================================================
+current cycle (v1.10.. aka v1.11-rc), culprit identified
+========================================================
+
+
+[ *NEW* ] test_4_4_0: Lorem ipsum dolor sit amet
+------------------------------------------------
+https://linux-regtracking.leemhuis.info/regzbot/regression/lore/regzbot-testing-test_4_4_0@example.com/
+https://lore.kernel.org/regressions/regzbot-testing-test_4_4_0@example.com/
+
+By Regzbot testingmail; 12 days ago; 2 activities, latest 11 days ago.
+Introduced in 23bde5c338c7
+
+Recent activities from: Regzbot testingmail (2)
+
+Noteworthy links:
+* Link somewhere
+  https://www.kernel.org/releases.html
+  11 days ago, by Regzbot testingmail
+
+
+[ *NEW* ] test_4_0_1: Lorem ipsum dolor sit amet
+------------------------------------------------
+https://linux-regtracking.leemhuis.info/regzbot/regression/lore/regzbot-testing-test_4_0_1@example.com/
+https://lore.kernel.org/regressions/regzbot-testing-test_4_0_1@example.com/
+
+By Regzbot testingmail; 29 days ago; 1 activities, latest 29 days ago.
+Introduced in 23bde5c338c7
+
+Recent activities from: Regzbot testingmail (1)
+
+
+=====================================================
+current cycle (v1.10.. aka v1.11-rc), unknown culprit
+=====================================================
+
+
+[ *NEW* ] test_4_4_10: Lorem ipsum dolor sit amet
+-------------------------------------------------
+https://linux-regtracking.leemhuis.info/regzbot/regression/lore/regzbot-testing-test_4_4_10@example.com/
+https://lore.kernel.org/regressions/regzbot-testing-test_4_4_10@example.com/
+
+By Regzbot testingmail; 2 days ago; 2 activities, latest -335 days ago.
+Introduced in v1.10..v1.11-rc1
+
+Fix incoming:
+* Testcommit test_4_4
+  https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git/commit/?h=master&id=62f89ca29d354a42662bc61fc2e63ee6af41b3fd
+
+
+[ *NEW* ] test_4_4_4: Lorem ipsum dolor sit amet
+------------------------------------------------
+https://linux-regtracking.leemhuis.info/regzbot/regression/lore/regzbot-testing-test_4_4_4@example.com/
+https://lore.kernel.org/regressions/regzbot-testing-test_4_4_4@example.com/
+https://lore.kernel.org/regressions/regzbot-testing-test_4_4_6@example.com/
+
+By Regzbot testingmail and Regzbot testingmail; 8 days ago; 2 activities, latest 7 days ago.
+Introduced in v1.10..v1.11-rc1
+
+Fix incoming:
+* https://lore.kernel.org/regressions/regzbot-testing-test_4_4_5@example.com/
+
+
+[ *NEW* ] test_4_0_0: Lorem ipsum dolor sit amet
+------------------------------------------------
+https://linux-regtracking.leemhuis.info/regzbot/regression/lore/regzbot-testing-test_4_0_0@example.com/
+https://lore.kernel.org/regressions/regzbot-testing-test_4_0_0@example.com/
+
+By Regzbot testingmail; 30 days ago; 1 activities, latest 30 days ago.
+Introduced in v1.10..v1.11-rc1
+
+Recent activities from: Regzbot testingmail (1)
+
+
+=============
+End of report
+=============
+
+All regressions marked '[ *NEW* ]' were added since the previous report,
+which can be found here:
+https://lore.kernel.org/r/testing-lastreport@example.com
+
+Thanks for your attention, have a nice day!
+
+  Regzbot, your hard working Linux kernel regression tracking robot
+
+
+P.S.: Wanna know more about regzbot or how to use it to track regressions
+for your subsystem? Then check out the getting started guide or the
+reference documentation:
+
+https://gitlab.com/knurd42/regzbot/-/blob/main/docs/getting_started.md
+https://gitlab.com/knurd42/regzbot/-/blob/main/docs/reference.md
+
+The short version: if you see a regression report you want to see
+tracked, just send a reply to the report where you Cc
+regressions@lists.linux.dev with a line like this:
+
+#regzbot introduced: v5.13..v5.14-rc1
+
+If you want to fix a tracked regression, just do what is expected
+anyway: add a 'Link:' tag with the url to the report, e.g.:
+
+Link: https://lore.kernel.org/all/30th.anniversary.repost@klaava.Helsinki.FI/
+-----END MAIL offltest_4_4-----
+
+-----BEGIN MAIL offltest_5_0-----
+
+---
+
+Hi, this is regzbot, the Linux kernel regression tracking bot.
+
+Currently I'm aware of 1 regressions in linux-mainline. Find the
+current status below and the latest on the web:
+
+https://linux-regtracking.leemhuis.info/regzbot/mainline/
+
+Bye bye, hope to see you soon for the next report.
+   Regzbot (on behalf of Thorsten Leemhuis)
+
+
+=====================================================
+current cycle (v1.10.. aka v1.11-rc), unknown culprit
+=====================================================
+
+
+[ *NEW* ] test_5_0: Lorem ipsum dolor sit amet
+----------------------------------------------
+https://linux-regtracking.leemhuis.info/regzbot/regression/lore/regzbot-testing-test_5_0@example.com/
+https://lore.kernel.org/regressions/regzbot-testing-test_5_0@example.com/
+
+By Regzbot testingmail; 30 days ago; 1 activities, latest 30 days ago.
+Introduced in v1.10..v1.11-rc1
+
+Recent activities from: Regzbot testingmail (1)
+
+
+=============
+End of report
+=============
+
+All regressions marked '[ *NEW* ]' were added since the previous report,
+which can be found here:
+https://lore.kernel.org/r/testing-lastreport@example.com
+
+Thanks for your attention, have a nice day!
+
+  Regzbot, your hard working Linux kernel regression tracking robot
+
+
+P.S.: Wanna know more about regzbot or how to use it to track regressions
+for your subsystem? Then check out the getting started guide or the
+reference documentation:
+
+https://gitlab.com/knurd42/regzbot/-/blob/main/docs/getting_started.md
+https://gitlab.com/knurd42/regzbot/-/blob/main/docs/reference.md
+
+The short version: if you see a regression report you want to see
+tracked, just send a reply to the report where you Cc
+regressions@lists.linux.dev with a line like this:
+
+#regzbot introduced: v5.13..v5.14-rc1
+
+If you want to fix a tracked regression, just do what is expected
+anyway: add a 'Link:' tag with the url to the report, e.g.:
+
+Link: https://lore.kernel.org/all/30th.anniversary.repost@klaava.Helsinki.FI/
+-----END MAIL offltest_5_0-----
+
+-----BEGIN MAIL offltest_5_1-----
+
+---
+
+Hi, this is regzbot, the Linux kernel regression tracking bot.
+
+Currently I'm aware of 1 regressions in linux-mainline. Find the
+current status below and the latest on the web:
+
+https://linux-regtracking.leemhuis.info/regzbot/mainline/
+
+Bye bye, hope to see you soon for the next report.
+   Regzbot (on behalf of Thorsten Leemhuis)
+
+
+=====================================================
+current cycle (v1.10.. aka v1.11-rc), unknown culprit
+=====================================================
+
+
+[ *NEW* ] test_5_0: Lorem ipsum dolor sit amet
+----------------------------------------------
+https://linux-regtracking.leemhuis.info/regzbot/regression/lore/regzbot-testing-test_5_0@example.com/
+https://lore.kernel.org/regressions/regzbot-testing-test_5_0@example.com/
+
+By Regzbot testingmail; 30 days ago; 2 activities, latest 29 days ago.
+Introduced in v1.10..v1.11-rc1
+
+Recent activities from: Regzbot testingmail (2)
+
+
+=============
+End of report
+=============
+
+All regressions marked '[ *NEW* ]' were added since the previous report,
+which can be found here:
+https://lore.kernel.org/r/testing-lastreport@example.com
+
+Thanks for your attention, have a nice day!
+
+  Regzbot, your hard working Linux kernel regression tracking robot
+
+
+P.S.: Wanna know more about regzbot or how to use it to track regressions
+for your subsystem? Then check out the getting started guide or the
+reference documentation:
+
+https://gitlab.com/knurd42/regzbot/-/blob/main/docs/getting_started.md
+https://gitlab.com/knurd42/regzbot/-/blob/main/docs/reference.md
+
+The short version: if you see a regression report you want to see
+tracked, just send a reply to the report where you Cc
+regressions@lists.linux.dev with a line like this:
+
+#regzbot introduced: v5.13..v5.14-rc1
+
+If you want to fix a tracked regression, just do what is expected
+anyway: add a 'Link:' tag with the url to the report, e.g.:
+
+Link: https://lore.kernel.org/all/30th.anniversary.repost@klaava.Helsinki.FI/
+-----END MAIL offltest_5_1-----
+
+-----BEGIN MAIL offltest_5_2-----
+
+---
+
+Hi, this is regzbot, the Linux kernel regression tracking bot.
+
+Currently I'm aware of 1 regressions in linux-mainline. Find the
+current status below and the latest on the web:
+
+https://linux-regtracking.leemhuis.info/regzbot/mainline/
+
+Bye bye, hope to see you soon for the next report.
+   Regzbot (on behalf of Thorsten Leemhuis)
+
+
+=====================================================
+current cycle (v1.10.. aka v1.11-rc), unknown culprit
+=====================================================
+
+
+[ *NEW* ] test_5_0: Lorem ipsum dolor sit amet
+----------------------------------------------
+https://linux-regtracking.leemhuis.info/regzbot/regression/lore/regzbot-testing-test_5_0@example.com/
+https://lore.kernel.org/regressions/regzbot-testing-test_5_0@example.com/
+
+By Regzbot testingmail; 30 days ago; 7 activities, latest 23 days ago.
+Introduced in v1.10..v1.11-rc1
+
+Recent activities from: Regzbot testingmail (7)
+
+
+=============
+End of report
+=============
+
+All regressions marked '[ *NEW* ]' were added since the previous report,
+which can be found here:
+https://lore.kernel.org/r/testing-lastreport@example.com
+
+Thanks for your attention, have a nice day!
+
+  Regzbot, your hard working Linux kernel regression tracking robot
+
+
+P.S.: Wanna know more about regzbot or how to use it to track regressions
+for your subsystem? Then check out the getting started guide or the
+reference documentation:
+
+https://gitlab.com/knurd42/regzbot/-/blob/main/docs/getting_started.md
+https://gitlab.com/knurd42/regzbot/-/blob/main/docs/reference.md
+
+The short version: if you see a regression report you want to see
+tracked, just send a reply to the report where you Cc
+regressions@lists.linux.dev with a line like this:
+
+#regzbot introduced: v5.13..v5.14-rc1
+
+If you want to fix a tracked regression, just do what is expected
+anyway: add a 'Link:' tag with the url to the report, e.g.:
+
+Link: https://lore.kernel.org/all/30th.anniversary.repost@klaava.Helsinki.FI/
+-----END MAIL offltest_5_2-----
+
+-----BEGIN MAIL offltest_6_0-----
+-----END MAIL offltest_6_0-----
+
+-----BEGIN MAIL offltest_6_1-----
+-----END MAIL offltest_6_1-----
+
+================================================================================
+= WEB REPORTS
+================================================================================
+-----BEGIN WEB offltest_0_0-----
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+</head>
+<body>
+  <script src="../relativetime.js" type="text/javascript"></script>
+  <h1>Linux kernel regression status</h1>
+  <h2><a href="../next/">[next]</a>&nbsp;[mainline]&nbsp;<a href="../stable/">[stable/longterm]</a>&nbsp;•&nbsp;<a href="../new/">[new]</a>&nbsp;•&nbsp;<a href="../all/">[all]</a>&nbsp;•&nbsp;<a href="../resolved/">[resolved]</a>&nbsp;<a href="../inconclusive/">[inconclusive]</a>&nbsp;</h2>
+  <table style="width:100%;">
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>current cycle (v1.10.. aka v1.11-rc), culprit identified</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>current cycle (v1.10.. aka v1.11-rc), unknown culprit</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>previous cycle (v1.9..v1.10), culprit identified, with activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>older cycles (..v1.9), culprit identified, with activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>previous cycle (v1.9..v1.10), unknown culprit, with activity in the past three weeks</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>older cycles (..v1.9), unknown culprit, with activity in the past three weeks</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>all others with unknown culprit and activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.8..v1.9-rc1</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_0_0: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_0@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_0_0@example.com/">activity</a>: <script type="text/javascript">timeAgo(1546304400000);</script>.</div></summary>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_0@example.com/">test_0_0: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546304400000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_0@example.com/">introduced: v1.8..v1.9-rc1</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546304400000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li></li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_0_0@example.com/">https://lore.kernel.org/r/regzbot-testing-test_0_0@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>on back burner with activity in the past six months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+  </table>
+  <hr>
+  <p style="text-align: center">[compiled by <a href="https://linux-regtracking.leemhuis.info">regzbot</a> on 2019-01-31 01:00:00 (UTC). Wanna know more about regzbot? Then check out its <a href="https://gitlab.com/knurd42/regzbot/-/blob/main/docs/getting_started.md">getting started guide</a> or its <a href="https://gitlab.com/knurd42/regzbot/-/blob/main/docs/reference.md">reference documentation</a>.]</p>
+</body>
+-----END WEB offltest_0_0-----
+
+-----BEGIN WEB offltest_0_1-----
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+</head>
+<body>
+  <script src="../relativetime.js" type="text/javascript"></script>
+  <h1>Linux kernel regression status</h1>
+  <h2><a href="../next/">[next]</a>&nbsp;[mainline]&nbsp;<a href="../stable/">[stable/longterm]</a>&nbsp;•&nbsp;<a href="../new/">[new]</a>&nbsp;•&nbsp;<a href="../all/">[all]</a>&nbsp;•&nbsp;<a href="../resolved/">[resolved]</a>&nbsp;<a href="../inconclusive/">[inconclusive]</a>&nbsp;</h2>
+  <table style="width:100%;">
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>current cycle (v1.10.. aka v1.11-rc), culprit identified</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>current cycle (v1.10.. aka v1.11-rc), unknown culprit</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>previous cycle (v1.9..v1.10), culprit identified, with activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>
+            <a href="https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?h=master&amp;id=4ddd01e474b98c0273c0fced667588abf78f3783">4ddd01e474b9</a>
+            <div>(v1.10-rc1^0)</div>
+          </li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_0_0: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_0@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_0_0@example.com/">activity</a>: <a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_0@example.com/"><script type="text/javascript">timeAgo(1546304400000);</script></a> &amp; <a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_1@example.com/"><script type="text/javascript">timeAgo(1546390800000);</script></a>.</div></summary>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_1@example.com/">test_0_1: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546390800000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_0@example.com/">test_0_0: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546304400000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_1@example.com/">introduced: 4ddd01e474b98c0273c0fced667588abf78f3783</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546390800000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_0@example.com/">introduced: v1.8..v1.9-rc1</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546304400000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li>Fixes: 4ddd01e474b9 ("This is a mainline_master commit for testing regzbot, the content doesn't matter.")</li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_0_0@example.com/">https://lore.kernel.org/r/regzbot-testing-test_0_0@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>older cycles (..v1.9), culprit identified, with activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>previous cycle (v1.9..v1.10), unknown culprit, with activity in the past three weeks</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>older cycles (..v1.9), unknown culprit, with activity in the past three weeks</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>all others with unknown culprit and activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>on back burner with activity in the past six months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+  </table>
+  <hr>
+  <p style="text-align: center">[compiled by <a href="https://linux-regtracking.leemhuis.info">regzbot</a> on 2019-01-31 01:00:00 (UTC). Wanna know more about regzbot? Then check out its <a href="https://gitlab.com/knurd42/regzbot/-/blob/main/docs/getting_started.md">getting started guide</a> or its <a href="https://gitlab.com/knurd42/regzbot/-/blob/main/docs/reference.md">reference documentation</a>.]</p>
+</body>
+-----END WEB offltest_0_1-----
+
+-----BEGIN WEB offltest_0_2-----
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+</head>
+<body>
+  <script src="../relativetime.js" type="text/javascript"></script>
+  <h1>Linux kernel regression status</h1>
+  <h2><a href="../next/">[next]</a>&nbsp;[mainline]&nbsp;<a href="../stable/">[stable/longterm]</a>&nbsp;•&nbsp;<a href="../new/">[new]</a>&nbsp;•&nbsp;<a href="../all/">[all]</a>&nbsp;•&nbsp;<a href="../resolved/">[resolved]</a>&nbsp;<a href="../inconclusive/">[inconclusive]</a>&nbsp;</h2>
+  <table style="width:100%;">
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>current cycle (v1.10.. aka v1.11-rc), culprit identified</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>current cycle (v1.10.. aka v1.11-rc), unknown culprit</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>previous cycle (v1.9..v1.10), culprit identified, with activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>
+            <a href="https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?h=master&amp;id=4ddd01e474b98c0273c0fced667588abf78f3783">4ddd01e474b9</a>
+            <div>(v1.10-rc1^0)</div>
+          </li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_0_0: updated title (set by test_0_2)</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_0@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_0_0@example.com/">activity</a>: <a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_0@example.com/"><script type="text/javascript">timeAgo(1546304400000);</script></a> &amp; <a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_2@example.com/"><script type="text/javascript">timeAgo(1546477200000);</script></a>.</div></summary>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_2@example.com/">test_0_2: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546477200000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_1@example.com/">test_0_1: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546390800000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_0@example.com/">test_0_0: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546304400000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_2@example.com/">summary: test_0_0: updated title (set by test_0_2)</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546477200000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_1@example.com/">introduced: 4ddd01e474b98c0273c0fced667588abf78f3783</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546390800000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_0@example.com/">introduced: v1.8..v1.9-rc1</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546304400000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li>Fixes: 4ddd01e474b9 ("This is a mainline_master commit for testing regzbot, the content doesn't matter.")</li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_0_0@example.com/">https://lore.kernel.org/r/regzbot-testing-test_0_0@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>older cycles (..v1.9), culprit identified, with activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>previous cycle (v1.9..v1.10), unknown culprit, with activity in the past three weeks</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>older cycles (..v1.9), unknown culprit, with activity in the past three weeks</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>all others with unknown culprit and activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>on back burner with activity in the past six months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+  </table>
+  <hr>
+  <p style="text-align: center">[compiled by <a href="https://linux-regtracking.leemhuis.info">regzbot</a> on 2019-01-31 01:00:00 (UTC). Wanna know more about regzbot? Then check out its <a href="https://gitlab.com/knurd42/regzbot/-/blob/main/docs/getting_started.md">getting started guide</a> or its <a href="https://gitlab.com/knurd42/regzbot/-/blob/main/docs/reference.md">reference documentation</a>.]</p>
+</body>
+-----END WEB offltest_0_2-----
+
+-----BEGIN WEB offltest_0_3-----
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+</head>
+<body>
+  <script src="../relativetime.js" type="text/javascript"></script>
+  <h1>Linux kernel regression status</h1>
+  <h2><a href="../next/">[next]</a>&nbsp;[mainline]&nbsp;<a href="../stable/">[stable/longterm]</a>&nbsp;•&nbsp;<a href="../new/">[new]</a>&nbsp;•&nbsp;<a href="../all/">[all]</a>&nbsp;•&nbsp;<a href="../resolved/">[resolved]</a>&nbsp;<a href="../inconclusive/">[inconclusive]</a>&nbsp;</h2>
+  <table style="width:100%;">
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>current cycle (v1.10.. aka v1.11-rc), culprit identified</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>current cycle (v1.10.. aka v1.11-rc), unknown culprit</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>previous cycle (v1.9..v1.10), culprit identified, with activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>
+            <a href="https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?h=master&amp;id=4ddd01e474b98c0273c0fced667588abf78f3783">4ddd01e474b9</a>
+            <div>(v1.10-rc1^0)</div>
+          </li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_0_0: updated title (set by test_0_2)</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_0@example.com/">Regzbot testingmail</a> and <a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_3@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_0_3@example.com/">activity</a>: <a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_0@example.com/"><script type="text/javascript">timeAgo(1546304400000);</script></a> &amp; <a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_3_1@example.com/"><script type="text/javascript">timeAgo(1546650000000);</script></a>.</div></summary>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_3_1@example.com/">test_0_3_1: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546650000000);</script>, by Regzbot testingmail [<a href="../regression/lore/regzbot-testing-test_0_3@example.com/">via dup</a>]</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_3@example.com/">test_0_3: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546563600000);</script>, by Regzbot testingmail [<a href="../regression/lore/regzbot-testing-test_0_3@example.com/">via dup</a>]</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_2@example.com/">test_0_2: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546477200000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_1@example.com/">test_0_1: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546390800000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_0@example.com/">test_0_0: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546304400000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_3_1@example.com/">duplicate: https://lore.kernel.org/regressions/regzbot-testing-test_0_3@example.com/ [implicit via duplicate]</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546650000000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_2@example.com/">summary: test_0_0: updated title (set by test_0_2)</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546477200000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_1@example.com/">introduced: 4ddd01e474b98c0273c0fced667588abf78f3783</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546390800000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_0@example.com/">introduced: v1.8..v1.9-rc1</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546304400000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li>Fixes: 4ddd01e474b9 ("This is a mainline_master commit for testing regzbot, the content doesn't matter.")</li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_0_0@example.com/">https://lore.kernel.org/r/regzbot-testing-test_0_0@example.com/</a></li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_0_3@example.com/">https://lore.kernel.org/r/regzbot-testing-test_0_3@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>older cycles (..v1.9), culprit identified, with activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>previous cycle (v1.9..v1.10), unknown culprit, with activity in the past three weeks</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>older cycles (..v1.9), unknown culprit, with activity in the past three weeks</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>all others with unknown culprit and activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>on back burner with activity in the past six months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+  </table>
+  <hr>
+  <p style="text-align: center">[compiled by <a href="https://linux-regtracking.leemhuis.info">regzbot</a> on 2019-01-31 01:00:00 (UTC). Wanna know more about regzbot? Then check out its <a href="https://gitlab.com/knurd42/regzbot/-/blob/main/docs/getting_started.md">getting started guide</a> or its <a href="https://gitlab.com/knurd42/regzbot/-/blob/main/docs/reference.md">reference documentation</a>.]</p>
+</body>
+-----END WEB offltest_0_3-----
+
+-----BEGIN WEB offltest_0_4-----
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+</head>
+<body>
+  <script src="../relativetime.js" type="text/javascript"></script>
+  <h1>Linux kernel regression status</h1>
+  <h2><a href="../next/">[next]</a>&nbsp;[mainline]&nbsp;<a href="../stable/">[stable/longterm]</a>&nbsp;•&nbsp;<a href="../new/">[new]</a>&nbsp;•&nbsp;<a href="../all/">[all]</a>&nbsp;•&nbsp;<a href="../resolved/">[resolved]</a>&nbsp;<a href="../inconclusive/">[inconclusive]</a>&nbsp;</h2>
+  <table style="width:100%;">
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>current cycle (v1.10.. aka v1.11-rc), culprit identified</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>current cycle (v1.10.. aka v1.11-rc), unknown culprit</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>previous cycle (v1.9..v1.10), culprit identified, with activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>
+            <a href="https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?h=master&amp;id=4ddd01e474b98c0273c0fced667588abf78f3783">4ddd01e474b9</a>
+            <div>(v1.10-rc1^0)</div>
+          </li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_0_0: updated title (set by test_0_2)</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_0@example.com/">Regzbot testingmail</a> and <a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_3@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_0_3@example.com/">activity</a>: <a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_0@example.com/"><script type="text/javascript">timeAgo(1546304400000);</script></a> &amp; <a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_4@example.com/"><script type="text/javascript">timeAgo(1546736400000);</script></a>. Noteworthy: <mark style="background-color: #D0D0D0;">[<a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_4@example.com/">fix incoming</a>]</mark>.</div></summary>
+          <div>
+            <strong>Fix incoming: </strong>
+            <a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_4@example.com/">
+              <i>4169881b9e07 ("Testcomment to fixed-by")</i>
+            </a>
+            <div style="padding-left: 3em;">
+              <script type="text/javascript">timeAgo(1546736400000);</script>
+            </div>
+          </div>
+          <p>Latest five known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_4@example.com/">test_0_4: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546736400000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_3_1@example.com/">test_0_3_1: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546650000000);</script>, by Regzbot testingmail [<a href="../regression/lore/regzbot-testing-test_0_3@example.com/">via dup</a>]</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_3@example.com/">test_0_3: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546563600000);</script>, by Regzbot testingmail [<a href="../regression/lore/regzbot-testing-test_0_3@example.com/">via dup</a>]</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_2@example.com/">test_0_2: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546477200000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_1@example.com/">test_0_1: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546390800000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_4@example.com/">fix: 4169881b9e0781b2286dc94e4cb731982c5371aa Testcomment to fixed-by</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546736400000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_3_1@example.com/">duplicate: https://lore.kernel.org/regressions/regzbot-testing-test_0_3@example.com/ [implicit via duplicate]</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546650000000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_2@example.com/">summary: test_0_0: updated title (set by test_0_2)</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546477200000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_1@example.com/">introduced: 4ddd01e474b98c0273c0fced667588abf78f3783</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546390800000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_0@example.com/">introduced: v1.8..v1.9-rc1</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546304400000);</script>, by Regzbot testingmail</div></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>older cycles (..v1.9), culprit identified, with activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>previous cycle (v1.9..v1.10), unknown culprit, with activity in the past three weeks</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>older cycles (..v1.9), unknown culprit, with activity in the past three weeks</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>all others with unknown culprit and activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>on back burner with activity in the past six months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+  </table>
+  <hr>
+  <p style="text-align: center">[compiled by <a href="https://linux-regtracking.leemhuis.info">regzbot</a> on 2019-01-31 01:00:00 (UTC). Wanna know more about regzbot? Then check out its <a href="https://gitlab.com/knurd42/regzbot/-/blob/main/docs/getting_started.md">getting started guide</a> or its <a href="https://gitlab.com/knurd42/regzbot/-/blob/main/docs/reference.md">reference documentation</a>.]</p>
+</body>
+-----END WEB offltest_0_4-----
+
+-----BEGIN WEB offltest_0_5-----
+-----END WEB offltest_0_5-----
+
+-----BEGIN WEB offltest_0_6-----
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+</head>
+<body>
+  <script src="../relativetime.js" type="text/javascript"></script>
+  <h1>Linux kernel regression status</h1>
+  <h2><a href="../next/">[next]</a>&nbsp;[mainline]&nbsp;<a href="../stable/">[stable/longterm]</a>&nbsp;•&nbsp;<a href="../new/">[new]</a>&nbsp;•&nbsp;<a href="../all/">[all]</a>&nbsp;•&nbsp;<a href="../resolved/">[resolved]</a>&nbsp;<a href="../inconclusive/">[inconclusive]</a>&nbsp;</h2>
+  <table style="width:100%;">
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>current cycle (v1.10.. aka v1.11-rc), culprit identified</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>current cycle (v1.10.. aka v1.11-rc), unknown culprit</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>previous cycle (v1.9..v1.10), culprit identified, with activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>older cycles (..v1.9), culprit identified, with activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>previous cycle (v1.9..v1.10), unknown culprit, with activity in the past three weeks</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>older cycles (..v1.9), unknown culprit, with activity in the past three weeks</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>all others with unknown culprit and activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.8..v1.9-rc1</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_0_6: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_6@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_0_6@example.com/">activity</a>: <a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_6@example.com/"><script type="text/javascript">timeAgo(1546909200000);</script></a> &amp; <a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_6_1@example.com/"><script type="text/javascript">timeAgo(1546995600000);</script></a>.</div></summary>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_6_1@example.com/">test_0_6_1: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546995600000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_6@example.com/">test_0_6: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546909200000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_6_1@example.com/">introduced: v1.8..v1.9-rc1</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546995600000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li></li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_0_6@example.com/">https://lore.kernel.org/r/regzbot-testing-test_0_6@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>on back burner with activity in the past six months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+  </table>
+  <hr>
+  <p style="text-align: center">[compiled by <a href="https://linux-regtracking.leemhuis.info">regzbot</a> on 2019-01-31 01:00:00 (UTC). Wanna know more about regzbot? Then check out its <a href="https://gitlab.com/knurd42/regzbot/-/blob/main/docs/getting_started.md">getting started guide</a> or its <a href="https://gitlab.com/knurd42/regzbot/-/blob/main/docs/reference.md">reference documentation</a>.]</p>
+</body>
+-----END WEB offltest_0_6-----
+
+-----BEGIN WEB offltest_0_7-----
+-----END WEB offltest_0_7-----
+
+-----BEGIN WEB offltest_0_8-----
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+</head>
+<body>
+  <script src="../relativetime.js" type="text/javascript"></script>
+  <h1>Linux kernel regression status</h1>
+  <h2><a href="../next/">[next]</a>&nbsp;[mainline]&nbsp;<a href="../stable/">[stable/longterm]</a>&nbsp;•&nbsp;<a href="../new/">[new]</a>&nbsp;•&nbsp;<a href="../all/">[all]</a>&nbsp;•&nbsp;<a href="../resolved/">[resolved]</a>&nbsp;<a href="../inconclusive/">[inconclusive]</a>&nbsp;</h2>
+  <table style="width:100%;">
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>current cycle (v1.10.. aka v1.11-rc), culprit identified</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>current cycle (v1.10.. aka v1.11-rc), unknown culprit</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>previous cycle (v1.9..v1.10), culprit identified, with activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>older cycles (..v1.9), culprit identified, with activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>previous cycle (v1.9..v1.10), unknown culprit, with activity in the past three weeks</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>older cycles (..v1.9), unknown culprit, with activity in the past three weeks</strong>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.8..v1.9-rc1</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_0_8: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/lkml/regzbot-testing-test_0_8@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_0_8@example.com/">activity</a>: <script type="text/javascript">timeAgo(1547168400000);</script>.</div></summary>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/lkml/regzbot-testing-test_0_8@example.com/">test_0_8: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547168400000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/lkml/regzbot-testing-test_0_8@example.com/">introduced: v1.8..v1.9-rc1</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547168400000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li></li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_0_8@example.com/">https://lore.kernel.org/r/regzbot-testing-test_0_8@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>all others with unknown culprit and activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>on back burner with activity in the past six months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+  </table>
+  <hr>
+  <p style="text-align: center">[compiled by <a href="https://linux-regtracking.leemhuis.info">regzbot</a> on 2019-01-31 01:00:00 (UTC). Wanna know more about regzbot? Then check out its <a href="https://gitlab.com/knurd42/regzbot/-/blob/main/docs/getting_started.md">getting started guide</a> or its <a href="https://gitlab.com/knurd42/regzbot/-/blob/main/docs/reference.md">reference documentation</a>.]</p>
+</body>
+-----END WEB offltest_0_8-----
+
+-----BEGIN WEB offltest_0_9-----
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+</head>
+<body>
+  <script src="../relativetime.js" type="text/javascript"></script>
+  <h1>Linux kernel regression status</h1>
+  <h2><a href="../next/">[next]</a>&nbsp;[mainline]&nbsp;<a href="../stable/">[stable/longterm]</a>&nbsp;•&nbsp;<a href="../new/">[new]</a>&nbsp;•&nbsp;<a href="../all/">[all]</a>&nbsp;•&nbsp;<a href="../resolved/">[resolved]</a>&nbsp;<a href="../inconclusive/">[inconclusive]</a>&nbsp;</h2>
+  <table style="width:100%;">
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>current cycle (v1.10.. aka v1.11-rc), culprit identified</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>current cycle (v1.10.. aka v1.11-rc), unknown culprit</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>previous cycle (v1.9..v1.10), culprit identified, with activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>older cycles (..v1.9), culprit identified, with activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>previous cycle (v1.9..v1.10), unknown culprit, with activity in the past three weeks</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>older cycles (..v1.9), unknown culprit, with activity in the past three weeks</strong>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.8..v1.9-rc1</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_0_9_0: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_9_0@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_0_9_0@example.com/">activity</a>: <a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_9_0@example.com/"><script type="text/javascript">timeAgo(1547254800000);</script></a> &amp; <a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_9_2@example.com/"><script type="text/javascript">timeAgo(1547427600000);</script></a>.</div></summary>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_9_2@example.com/">test_0_9_2: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547427600000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_9_1@example.com/">test_0_9_1: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547341200000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_9_0@example.com/">test_0_9_0: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547254800000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_9_2@example.com/">introduced: v1.8..v1.9-rc1</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547427600000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li></li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_0_9_0@example.com/">https://lore.kernel.org/r/regzbot-testing-test_0_9_0@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.8..v1.9-rc1</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_0_8: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/lkml/regzbot-testing-test_0_8@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_0_8@example.com/">activity</a>: <script type="text/javascript">timeAgo(1547168400000);</script>.</div></summary>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/lkml/regzbot-testing-test_0_8@example.com/">test_0_8: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547168400000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/lkml/regzbot-testing-test_0_8@example.com/">introduced: v1.8..v1.9-rc1</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547168400000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li></li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_0_8@example.com/">https://lore.kernel.org/r/regzbot-testing-test_0_8@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>all others with unknown culprit and activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>on back burner with activity in the past six months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+  </table>
+  <hr>
+  <p style="text-align: center">[compiled by <a href="https://linux-regtracking.leemhuis.info">regzbot</a> on 2019-01-31 01:00:00 (UTC). Wanna know more about regzbot? Then check out its <a href="https://gitlab.com/knurd42/regzbot/-/blob/main/docs/getting_started.md">getting started guide</a> or its <a href="https://gitlab.com/knurd42/regzbot/-/blob/main/docs/reference.md">reference documentation</a>.]</p>
+</body>
+-----END WEB offltest_0_9-----
+
+-----BEGIN WEB offltest_0_10-----
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+</head>
+<body>
+  <script src="../relativetime.js" type="text/javascript"></script>
+  <h1>Linux kernel regression status</h1>
+  <h2><a href="../next/">[next]</a>&nbsp;[mainline]&nbsp;<a href="../stable/">[stable/longterm]</a>&nbsp;•&nbsp;<a href="../new/">[new]</a>&nbsp;•&nbsp;<a href="../all/">[all]</a>&nbsp;•&nbsp;<a href="../resolved/">[resolved]</a>&nbsp;<a href="../inconclusive/">[inconclusive]</a>&nbsp;</h2>
+  <table style="width:100%;">
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>current cycle (v1.10.. aka v1.11-rc), culprit identified</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>current cycle (v1.10.. aka v1.11-rc), unknown culprit</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>previous cycle (v1.9..v1.10), culprit identified, with activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>older cycles (..v1.9), culprit identified, with activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>previous cycle (v1.9..v1.10), unknown culprit, with activity in the past three weeks</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>older cycles (..v1.9), unknown culprit, with activity in the past three weeks</strong>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.8..v1.9-rc1</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>updated title, set by test_0_10_0</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_9_0@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_0_9_0@example.com/">activity</a>: <a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_9_0@example.com/"><script type="text/javascript">timeAgo(1547254800000);</script></a> &amp; <a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_9_2@example.com/"><script type="text/javascript">timeAgo(1547427600000);</script></a>.</div></summary>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_9_2@example.com/">test_0_9_2: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547427600000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_9_1@example.com/">test_0_9_1: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547341200000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_9_0@example.com/">test_0_9_0: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547254800000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_10_0@example.com/">summary: updated title, set by test_0_10_0</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547514000000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_9_2@example.com/">introduced: v1.8..v1.9-rc1</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547427600000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li></li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_0_9_0@example.com/">https://lore.kernel.org/r/regzbot-testing-test_0_9_0@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.8..v1.9-rc1</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_0_8: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/lkml/regzbot-testing-test_0_8@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_0_8@example.com/">activity</a>: <script type="text/javascript">timeAgo(1547168400000);</script>.</div></summary>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/lkml/regzbot-testing-test_0_8@example.com/">test_0_8: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547168400000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/lkml/regzbot-testing-test_0_8@example.com/">introduced: v1.8..v1.9-rc1</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547168400000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li></li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_0_8@example.com/">https://lore.kernel.org/r/regzbot-testing-test_0_8@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>all others with unknown culprit and activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>on back burner with activity in the past six months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+  </table>
+  <hr>
+  <p style="text-align: center">[compiled by <a href="https://linux-regtracking.leemhuis.info">regzbot</a> on 2019-01-31 01:00:00 (UTC). Wanna know more about regzbot? Then check out its <a href="https://gitlab.com/knurd42/regzbot/-/blob/main/docs/getting_started.md">getting started guide</a> or its <a href="https://gitlab.com/knurd42/regzbot/-/blob/main/docs/reference.md">reference documentation</a>.]</p>
+</body>
+-----END WEB offltest_0_10-----
+
+-----BEGIN WEB offltest_0_11-----
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+</head>
+<body>
+  <script src="../relativetime.js" type="text/javascript"></script>
+  <h1>Linux kernel regression status</h1>
+  <h2><a href="../next/">[next]</a>&nbsp;[mainline]&nbsp;<a href="../stable/">[stable/longterm]</a>&nbsp;•&nbsp;<a href="../new/">[new]</a>&nbsp;•&nbsp;<a href="../all/">[all]</a>&nbsp;•&nbsp;<a href="../resolved/">[resolved]</a>&nbsp;<a href="../inconclusive/">[inconclusive]</a>&nbsp;</h2>
+  <table style="width:100%;">
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>current cycle (v1.10.. aka v1.11-rc), culprit identified</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>current cycle (v1.10.. aka v1.11-rc), unknown culprit</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>previous cycle (v1.9..v1.10), culprit identified, with activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>older cycles (..v1.9), culprit identified, with activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>previous cycle (v1.9..v1.10), unknown culprit, with activity in the past three weeks</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>older cycles (..v1.9), unknown culprit, with activity in the past three weeks</strong>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.8..v1.9-rc1</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>updated title, set by test_0_10_0</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_9_0@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_0_9_0@example.com/">activity</a>: <a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_9_0@example.com/"><script type="text/javascript">timeAgo(1547254800000);</script></a> &amp; <a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_9_2@example.com/"><script type="text/javascript">timeAgo(1547427600000);</script></a>; poked <a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_11_0@example.com/"><script type="text/javascript">timeAgo(1547600400000);</script></a>.</div></summary>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_9_2@example.com/">test_0_9_2: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547427600000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_9_1@example.com/">test_0_9_1: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547341200000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_9_0@example.com/">test_0_9_0: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547254800000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_11_0@example.com/">poke</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547600400000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_10_0@example.com/">summary: updated title, set by test_0_10_0</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547514000000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_9_2@example.com/">introduced: v1.8..v1.9-rc1</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547427600000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li></li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_0_9_0@example.com/">https://lore.kernel.org/r/regzbot-testing-test_0_9_0@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.8..v1.9-rc1</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_0_8: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/lkml/regzbot-testing-test_0_8@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_0_8@example.com/">activity</a>: <script type="text/javascript">timeAgo(1547168400000);</script>.</div></summary>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/lkml/regzbot-testing-test_0_8@example.com/">test_0_8: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547168400000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/lkml/regzbot-testing-test_0_8@example.com/">introduced: v1.8..v1.9-rc1</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547168400000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li></li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_0_8@example.com/">https://lore.kernel.org/r/regzbot-testing-test_0_8@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>all others with unknown culprit and activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>on back burner with activity in the past six months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+  </table>
+  <hr>
+  <p style="text-align: center">[compiled by <a href="https://linux-regtracking.leemhuis.info">regzbot</a> on 2019-01-31 01:00:00 (UTC). Wanna know more about regzbot? Then check out its <a href="https://gitlab.com/knurd42/regzbot/-/blob/main/docs/getting_started.md">getting started guide</a> or its <a href="https://gitlab.com/knurd42/regzbot/-/blob/main/docs/reference.md">reference documentation</a>.]</p>
+</body>
+-----END WEB offltest_0_11-----
+
+-----BEGIN WEB offltest_0_12-----
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+</head>
+<body>
+  <script src="../relativetime.js" type="text/javascript"></script>
+  <h1>Linux kernel regression status</h1>
+  <h2><a href="../next/">[next]</a>&nbsp;[mainline]&nbsp;<a href="../stable/">[stable/longterm]</a>&nbsp;•&nbsp;<a href="../new/">[new]</a>&nbsp;•&nbsp;<a href="../all/">[all]</a>&nbsp;•&nbsp;<a href="../resolved/">[resolved]</a>&nbsp;<a href="../inconclusive/">[inconclusive]</a>&nbsp;</h2>
+  <table style="width:100%;">
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>current cycle (v1.10.. aka v1.11-rc), culprit identified</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>current cycle (v1.10.. aka v1.11-rc), unknown culprit</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>previous cycle (v1.9..v1.10), culprit identified, with activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>older cycles (..v1.9), culprit identified, with activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>previous cycle (v1.9..v1.10), unknown culprit, with activity in the past three weeks</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>older cycles (..v1.9), unknown culprit, with activity in the past three weeks</strong>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.8..v1.9-rc1</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>updated title, set by test_0_10_0</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_9_0@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_0_9_0@example.com/">activity</a>: <a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_9_0@example.com/"><script type="text/javascript">timeAgo(1547254800000);</script></a> &amp; <a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_9_2@example.com/"><script type="text/javascript">timeAgo(1547427600000);</script></a>; poked <a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_11_0@example.com/"><script type="text/javascript">timeAgo(1547600400000);</script></a>.</div></summary>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_9_2@example.com/">test_0_9_2: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547427600000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_9_1@example.com/">test_0_9_1: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547341200000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_9_0@example.com/">test_0_9_0: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547254800000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_11_0@example.com/">poke</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547600400000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_10_0@example.com/">summary: updated title, set by test_0_10_0</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547514000000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_9_2@example.com/">introduced: v1.8..v1.9-rc1</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547427600000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li></li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_0_9_0@example.com/">https://lore.kernel.org/r/regzbot-testing-test_0_9_0@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.8..v1.9-rc1</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_0_8: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/lkml/regzbot-testing-test_0_8@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_0_8@example.com/">activity</a>: <script type="text/javascript">timeAgo(1547168400000);</script>.</div></summary>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/lkml/regzbot-testing-test_0_8@example.com/">test_0_8: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547168400000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/lkml/regzbot-testing-test_0_8@example.com/">introduced: v1.8..v1.9-rc1</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547168400000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li></li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_0_8@example.com/">https://lore.kernel.org/r/regzbot-testing-test_0_8@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>all others with unknown culprit and activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>on back burner with activity in the past six months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+  </table>
+  <hr>
+  <p style="text-align: center">[compiled by <a href="https://linux-regtracking.leemhuis.info">regzbot</a> on 2019-01-31 01:00:00 (UTC). Wanna know more about regzbot? Then check out its <a href="https://gitlab.com/knurd42/regzbot/-/blob/main/docs/getting_started.md">getting started guide</a> or its <a href="https://gitlab.com/knurd42/regzbot/-/blob/main/docs/reference.md">reference documentation</a>.]</p>
+</body>
+-----END WEB offltest_0_12-----
+
+-----BEGIN WEB offltest_0_13-----
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+</head>
+<body>
+  <script src="../relativetime.js" type="text/javascript"></script>
+  <h1>Linux kernel regression status</h1>
+  <h2><a href="../next/">[next]</a>&nbsp;[mainline]&nbsp;<a href="../stable/">[stable/longterm]</a>&nbsp;•&nbsp;<a href="../new/">[new]</a>&nbsp;•&nbsp;<a href="../all/">[all]</a>&nbsp;•&nbsp;<a href="../resolved/">[resolved]</a>&nbsp;<a href="../inconclusive/">[inconclusive]</a>&nbsp;</h2>
+  <table style="width:100%;">
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>current cycle (v1.10.. aka v1.11-rc), culprit identified</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>current cycle (v1.10.. aka v1.11-rc), unknown culprit</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>previous cycle (v1.9..v1.10), culprit identified, with activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>older cycles (..v1.9), culprit identified, with activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>previous cycle (v1.9..v1.10), unknown culprit, with activity in the past three weeks</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>older cycles (..v1.9), unknown culprit, with activity in the past three weeks</strong>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.8..v1.9-rc1</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_0_8: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/lkml/regzbot-testing-test_0_8@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_0_8@example.com/">activity</a>: <script type="text/javascript">timeAgo(1547168400000);</script>.</div></summary>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/lkml/regzbot-testing-test_0_8@example.com/">test_0_8: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547168400000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/lkml/regzbot-testing-test_0_8@example.com/">introduced: v1.8..v1.9-rc1</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547168400000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li></li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_0_8@example.com/">https://lore.kernel.org/r/regzbot-testing-test_0_8@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>all others with unknown culprit and activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>on back burner with activity in the past six months</strong>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.8..v1.9-rc1</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>updated title, set by test_0_10_0</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_9_0@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_0_9_0@example.com/">activity</a>: <a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_9_0@example.com/"><script type="text/javascript">timeAgo(1547254800000);</script></a> &amp; <a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_13_0@example.com/"><script type="text/javascript">timeAgo(1547773200000);</script></a>.</div></summary>
+          <div>On back burner: <i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_13_0@example.com/">Some reason</a></i><div style="padding-left: 1em;"><script type="text/javascript">timeAgo(1547773200000);</script>, by Regzbot testingmail</div></div>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_13_0@example.com/">test_0_13_0: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547773200000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_9_2@example.com/">test_0_9_2: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547427600000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_9_1@example.com/">test_0_9_1: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547341200000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_9_0@example.com/">test_0_9_0: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547254800000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_13_0@example.com/">backburn: Some reason</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547773200000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_11_0@example.com/">poke</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547600400000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_10_0@example.com/">summary: updated title, set by test_0_10_0</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547514000000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_9_2@example.com/">introduced: v1.8..v1.9-rc1</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547427600000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li></li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_0_9_0@example.com/">https://lore.kernel.org/r/regzbot-testing-test_0_9_0@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+  </table>
+  <hr>
+  <p style="text-align: center">[compiled by <a href="https://linux-regtracking.leemhuis.info">regzbot</a> on 2019-01-31 01:00:00 (UTC). Wanna know more about regzbot? Then check out its <a href="https://gitlab.com/knurd42/regzbot/-/blob/main/docs/getting_started.md">getting started guide</a> or its <a href="https://gitlab.com/knurd42/regzbot/-/blob/main/docs/reference.md">reference documentation</a>.]</p>
+</body>
+-----END WEB offltest_0_13-----
+
+-----BEGIN WEB offltest_0_14-----
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+</head>
+<body>
+  <script src="../relativetime.js" type="text/javascript"></script>
+  <h1>Linux kernel regression status</h1>
+  <h2><a href="../next/">[next]</a>&nbsp;[mainline]&nbsp;<a href="../stable/">[stable/longterm]</a>&nbsp;•&nbsp;<a href="../new/">[new]</a>&nbsp;•&nbsp;<a href="../all/">[all]</a>&nbsp;•&nbsp;<a href="../resolved/">[resolved]</a>&nbsp;<a href="../inconclusive/">[inconclusive]</a>&nbsp;</h2>
+  <table style="width:100%;">
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>current cycle (v1.10.. aka v1.11-rc), culprit identified</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>current cycle (v1.10.. aka v1.11-rc), unknown culprit</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>previous cycle (v1.9..v1.10), culprit identified, with activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>older cycles (..v1.9), culprit identified, with activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>previous cycle (v1.9..v1.10), unknown culprit, with activity in the past three weeks</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>older cycles (..v1.9), unknown culprit, with activity in the past three weeks</strong>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.8..v1.9-rc1</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>updated title, set by test_0_10_0</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_9_0@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_0_9_0@example.com/">activity</a>: <a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_9_0@example.com/"><script type="text/javascript">timeAgo(1547254800000);</script></a> &amp; <a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_14_0@example.com/"><script type="text/javascript">timeAgo(1547859600000);</script></a>.</div></summary>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_14_0@example.com/">test_0_14_0: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547859600000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_13_0@example.com/">test_0_13_0: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547773200000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_9_2@example.com/">test_0_9_2: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547427600000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_9_1@example.com/">test_0_9_1: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547341200000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_9_0@example.com/">test_0_9_0: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547254800000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_14_0@example.com/">unbackburn</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547859600000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_13_0@example.com/">backburn: Some reason</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547773200000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_11_0@example.com/">poke</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547600400000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_10_0@example.com/">summary: updated title, set by test_0_10_0</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547514000000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_9_2@example.com/">introduced: v1.8..v1.9-rc1</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547427600000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li></li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_0_9_0@example.com/">https://lore.kernel.org/r/regzbot-testing-test_0_9_0@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.8..v1.9-rc1</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_0_8: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/lkml/regzbot-testing-test_0_8@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_0_8@example.com/">activity</a>: <script type="text/javascript">timeAgo(1547168400000);</script>.</div></summary>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/lkml/regzbot-testing-test_0_8@example.com/">test_0_8: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547168400000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/lkml/regzbot-testing-test_0_8@example.com/">introduced: v1.8..v1.9-rc1</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547168400000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li></li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_0_8@example.com/">https://lore.kernel.org/r/regzbot-testing-test_0_8@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>all others with unknown culprit and activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>on back burner with activity in the past six months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+  </table>
+  <hr>
+  <p style="text-align: center">[compiled by <a href="https://linux-regtracking.leemhuis.info">regzbot</a> on 2019-01-31 01:00:00 (UTC). Wanna know more about regzbot? Then check out its <a href="https://gitlab.com/knurd42/regzbot/-/blob/main/docs/getting_started.md">getting started guide</a> or its <a href="https://gitlab.com/knurd42/regzbot/-/blob/main/docs/reference.md">reference documentation</a>.]</p>
+</body>
+-----END WEB offltest_0_14-----
+
+-----BEGIN WEB offltest_0_15-----
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+</head>
+<body>
+  <script src="../relativetime.js" type="text/javascript"></script>
+  <h1>Linux kernel regression status</h1>
+  <h2><a href="../next/">[next]</a>&nbsp;[mainline]&nbsp;<a href="../stable/">[stable/longterm]</a>&nbsp;•&nbsp;<a href="../new/">[new]</a>&nbsp;•&nbsp;<a href="../all/">[all]</a>&nbsp;•&nbsp;<a href="../resolved/">[resolved]</a>&nbsp;<a href="../inconclusive/">[inconclusive]</a>&nbsp;</h2>
+  <table style="width:100%;">
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>current cycle (v1.10.. aka v1.11-rc), culprit identified</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>current cycle (v1.10.. aka v1.11-rc), unknown culprit</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>previous cycle (v1.9..v1.10), culprit identified, with activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>older cycles (..v1.9), culprit identified, with activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>previous cycle (v1.9..v1.10), unknown culprit, with activity in the past three weeks</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>older cycles (..v1.9), unknown culprit, with activity in the past three weeks</strong>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.8..v1.9-rc1</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>updated title, set by test_0_10_0</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_9_0@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_0_9_0@example.com/">activity</a>: <a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_9_0@example.com/"><script type="text/javascript">timeAgo(1547254800000);</script></a> &amp; <a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_14_0@example.com/"><script type="text/javascript">timeAgo(1547859600000);</script></a>.</div></summary>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_14_0@example.com/">test_0_14_0: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547859600000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_13_0@example.com/">test_0_13_0: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547773200000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_9_2@example.com/">test_0_9_2: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547427600000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_9_1@example.com/">test_0_9_1: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547341200000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_9_0@example.com/">test_0_9_0: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547254800000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_14_0@example.com/">unbackburn</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547859600000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_13_0@example.com/">backburn: Some reason</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547773200000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_11_0@example.com/">poke</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547600400000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_10_0@example.com/">summary: updated title, set by test_0_10_0</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547514000000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_9_2@example.com/">introduced: v1.8..v1.9-rc1</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547427600000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li></li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_0_9_0@example.com/">https://lore.kernel.org/r/regzbot-testing-test_0_9_0@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.8..v1.9-rc1</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_0_8: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/lkml/regzbot-testing-test_0_8@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_0_8@example.com/">activity</a>: <script type="text/javascript">timeAgo(1547168400000);</script>.</div></summary>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/lkml/regzbot-testing-test_0_8@example.com/">test_0_8: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547168400000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/lkml/regzbot-testing-test_0_8@example.com/">introduced: v1.8..v1.9-rc1</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547168400000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li></li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_0_8@example.com/">https://lore.kernel.org/r/regzbot-testing-test_0_8@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>all others with unknown culprit and activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>on back burner with activity in the past six months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+  </table>
+  <hr>
+  <p style="text-align: center">[compiled by <a href="https://linux-regtracking.leemhuis.info">regzbot</a> on 2019-01-31 01:00:00 (UTC). Wanna know more about regzbot? Then check out its <a href="https://gitlab.com/knurd42/regzbot/-/blob/main/docs/getting_started.md">getting started guide</a> or its <a href="https://gitlab.com/knurd42/regzbot/-/blob/main/docs/reference.md">reference documentation</a>.]</p>
+</body>
+-----END WEB offltest_0_15-----
+
+-----BEGIN WEB offltest_0_16-----
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+</head>
+<body>
+  <script src="../relativetime.js" type="text/javascript"></script>
+  <h1>Linux kernel regression status</h1>
+  <h2><a href="../next/">[next]</a>&nbsp;[mainline]&nbsp;<a href="../stable/">[stable/longterm]</a>&nbsp;•&nbsp;<a href="../new/">[new]</a>&nbsp;•&nbsp;<a href="../all/">[all]</a>&nbsp;•&nbsp;<a href="../resolved/">[resolved]</a>&nbsp;<a href="../inconclusive/">[inconclusive]</a>&nbsp;</h2>
+  <table style="width:100%;">
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>current cycle (v1.10.. aka v1.11-rc), culprit identified</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>current cycle (v1.10.. aka v1.11-rc), unknown culprit</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>previous cycle (v1.9..v1.10), culprit identified, with activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>older cycles (..v1.9), culprit identified, with activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>previous cycle (v1.9..v1.10), unknown culprit, with activity in the past three weeks</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>older cycles (..v1.9), unknown culprit, with activity in the past three weeks</strong>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.8..v1.9-rc1</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>updated title, set by test_0_10_0</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_9_0@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_0_9_0@example.com/">activity</a>: <a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_9_0@example.com/"><script type="text/javascript">timeAgo(1547254800000);</script></a> &amp; <a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_14_0@example.com/"><script type="text/javascript">timeAgo(1547859600000);</script></a>.</div></summary>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_14_0@example.com/">test_0_14_0: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547859600000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_13_0@example.com/">test_0_13_0: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547773200000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_9_2@example.com/">test_0_9_2: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547427600000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_9_1@example.com/">test_0_9_1: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547341200000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_9_0@example.com/">test_0_9_0: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547254800000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_14_0@example.com/">unbackburn</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547859600000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_13_0@example.com/">backburn: Some reason</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547773200000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_11_0@example.com/">poke</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547600400000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_10_0@example.com/">summary: updated title, set by test_0_10_0</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547514000000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_9_2@example.com/">introduced: v1.8..v1.9-rc1</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547427600000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li></li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_0_9_0@example.com/">https://lore.kernel.org/r/regzbot-testing-test_0_9_0@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.8..v1.9-rc1</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_0_8: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/lkml/regzbot-testing-test_0_8@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_0_8@example.com/">activity</a>: <script type="text/javascript">timeAgo(1547168400000);</script>.</div></summary>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/lkml/regzbot-testing-test_0_8@example.com/">test_0_8: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547168400000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/lkml/regzbot-testing-test_0_8@example.com/">introduced: v1.8..v1.9-rc1</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547168400000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li></li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_0_8@example.com/">https://lore.kernel.org/r/regzbot-testing-test_0_8@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>all others with unknown culprit and activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>on back burner with activity in the past six months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+  </table>
+  <hr>
+  <p style="text-align: center">[compiled by <a href="https://linux-regtracking.leemhuis.info">regzbot</a> on 2019-01-31 01:00:00 (UTC). Wanna know more about regzbot? Then check out its <a href="https://gitlab.com/knurd42/regzbot/-/blob/main/docs/getting_started.md">getting started guide</a> or its <a href="https://gitlab.com/knurd42/regzbot/-/blob/main/docs/reference.md">reference documentation</a>.]</p>
+</body>
+-----END WEB offltest_0_16-----
+
+-----BEGIN WEB offltest_0_17-----
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+</head>
+<body>
+  <script src="../relativetime.js" type="text/javascript"></script>
+  <h1>Linux kernel regression status</h1>
+  <h2><a href="../next/">[next]</a>&nbsp;[mainline]&nbsp;<a href="../stable/">[stable/longterm]</a>&nbsp;•&nbsp;<a href="../new/">[new]</a>&nbsp;•&nbsp;<a href="../all/">[all]</a>&nbsp;•&nbsp;<a href="../resolved/">[resolved]</a>&nbsp;<a href="../inconclusive/">[inconclusive]</a>&nbsp;</h2>
+  <table style="width:100%;">
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>current cycle (v1.10.. aka v1.11-rc), culprit identified</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>current cycle (v1.10.. aka v1.11-rc), unknown culprit</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>previous cycle (v1.9..v1.10), culprit identified, with activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>older cycles (..v1.9), culprit identified, with activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>previous cycle (v1.9..v1.10), unknown culprit, with activity in the past three weeks</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>older cycles (..v1.9), unknown culprit, with activity in the past three weeks</strong>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.8..v1.9-rc1</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_0_17_0: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_17_0@example.com/">Regzbot testingmail</a> and <a href="https://lore.kernel.org/lkml/regzbot-testing-test_0_17_1@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_0_17_1@example.com/">activity</a>: <a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_17_0@example.com/"><script type="text/javascript">timeAgo(1548723600000);</script></a> &amp; <a href="https://lore.kernel.org/lkml/regzbot-testing-test_0_17_3@example.com/"><script type="text/javascript">timeAgo(1548982800000);</script></a>.</div></summary>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/lkml/regzbot-testing-test_0_17_3@example.com/">test_0_17_3: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1548982800000);</script>, by Regzbot testingmail [<a href="../regression/lore/regzbot-testing-test_0_17_1@example.com/">via dup</a>]</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_17_2@example.com/">test_0_17_2: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1548896400000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/lkml/regzbot-testing-test_0_17_1@example.com/">test_0_17_1: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1548810000000);</script>, by Regzbot testingmail [<a href="../regression/lore/regzbot-testing-test_0_17_1@example.com/">via dup</a>]</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_17_0@example.com/">test_0_17_0: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1548723600000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_17_2@example.com/">duplicate: https://lore.kernel.org/lkml/regzbot-testing-test_0_17_1@example.com</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1548896400000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_17_0@example.com/">introduced: v1.8..v1.9-rc1</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1548723600000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li></li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_0_17_0@example.com/">https://lore.kernel.org/r/regzbot-testing-test_0_17_0@example.com/</a></li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_0_17_1@example.com/">https://lore.kernel.org/r/regzbot-testing-test_0_17_1@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.8..v1.9-rc1</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>updated title, set by test_0_10_0</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_9_0@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_0_9_0@example.com/">activity</a>: <a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_9_0@example.com/"><script type="text/javascript">timeAgo(1547254800000);</script></a> &amp; <a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_14_0@example.com/"><script type="text/javascript">timeAgo(1547859600000);</script></a>.</div></summary>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_14_0@example.com/">test_0_14_0: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547859600000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_13_0@example.com/">test_0_13_0: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547773200000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_9_2@example.com/">test_0_9_2: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547427600000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_9_1@example.com/">test_0_9_1: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547341200000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_9_0@example.com/">test_0_9_0: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547254800000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_14_0@example.com/">unbackburn</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547859600000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_13_0@example.com/">backburn: Some reason</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547773200000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_11_0@example.com/">poke</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547600400000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_10_0@example.com/">summary: updated title, set by test_0_10_0</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547514000000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_9_2@example.com/">introduced: v1.8..v1.9-rc1</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547427600000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li></li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_0_9_0@example.com/">https://lore.kernel.org/r/regzbot-testing-test_0_9_0@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.8..v1.9-rc1</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_0_8: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/lkml/regzbot-testing-test_0_8@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_0_8@example.com/">activity</a>: <script type="text/javascript">timeAgo(1547168400000);</script>.</div></summary>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/lkml/regzbot-testing-test_0_8@example.com/">test_0_8: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547168400000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/lkml/regzbot-testing-test_0_8@example.com/">introduced: v1.8..v1.9-rc1</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547168400000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li></li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_0_8@example.com/">https://lore.kernel.org/r/regzbot-testing-test_0_8@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>all others with unknown culprit and activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>on back burner with activity in the past six months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+  </table>
+  <hr>
+  <p style="text-align: center">[compiled by <a href="https://linux-regtracking.leemhuis.info">regzbot</a> on 2019-01-31 01:00:00 (UTC). Wanna know more about regzbot? Then check out its <a href="https://gitlab.com/knurd42/regzbot/-/blob/main/docs/getting_started.md">getting started guide</a> or its <a href="https://gitlab.com/knurd42/regzbot/-/blob/main/docs/reference.md">reference documentation</a>.]</p>
+</body>
+-----END WEB offltest_0_17-----
+
+-----BEGIN WEB offltest_0_18-----
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+</head>
+<body>
+  <script src="../relativetime.js" type="text/javascript"></script>
+  <h1>Linux kernel regression status</h1>
+  <h2><a href="../next/">[next]</a>&nbsp;[mainline]&nbsp;<a href="../stable/">[stable/longterm]</a>&nbsp;•&nbsp;<a href="../new/">[new]</a>&nbsp;•&nbsp;<a href="../all/">[all]</a>&nbsp;•&nbsp;<a href="../resolved/">[resolved]</a>&nbsp;<a href="../inconclusive/">[inconclusive]</a>&nbsp;</h2>
+  <table style="width:100%;">
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>current cycle (v1.10.. aka v1.11-rc), culprit identified</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>current cycle (v1.10.. aka v1.11-rc), unknown culprit</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>previous cycle (v1.9..v1.10), culprit identified, with activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>older cycles (..v1.9), culprit identified, with activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>previous cycle (v1.9..v1.10), unknown culprit, with activity in the past three weeks</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>older cycles (..v1.9), unknown culprit, with activity in the past three weeks</strong>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.8..v1.9-rc1</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_0_18: Lorem ipsum dolor sit amet</i></strong> by <a href="https://bugzilla.example.com/show_bug.cgi?id=215744">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/generic/https://bugzilla.example.com/show_bug.cgi?id=215744/">activity</a>: <script type="text/javascript">timeAgo(1549069200000);</script>.</div></summary>
+          <p>
+            <ul style="padding-left: 5px; margin-top: -1em;"></ul>
+          </p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_18@example.com/">introduced: v1.8..v1.9-rc1</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1549069200000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li></li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://bugzilla.example.com/show_bug.cgi?id=215744">https://bugzilla.example.com/show_bug.cgi?id=215744</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.8..v1.9-rc1</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_0_17_0: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_17_0@example.com/">Regzbot testingmail</a> and <a href="https://lore.kernel.org/lkml/regzbot-testing-test_0_17_1@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_0_17_1@example.com/">activity</a>: <a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_17_0@example.com/"><script type="text/javascript">timeAgo(1548723600000);</script></a> &amp; <a href="https://lore.kernel.org/lkml/regzbot-testing-test_0_17_3@example.com/"><script type="text/javascript">timeAgo(1548982800000);</script></a>.</div></summary>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/lkml/regzbot-testing-test_0_17_3@example.com/">test_0_17_3: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1548982800000);</script>, by Regzbot testingmail [<a href="../regression/lore/regzbot-testing-test_0_17_1@example.com/">via dup</a>]</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_17_2@example.com/">test_0_17_2: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1548896400000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/lkml/regzbot-testing-test_0_17_1@example.com/">test_0_17_1: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1548810000000);</script>, by Regzbot testingmail [<a href="../regression/lore/regzbot-testing-test_0_17_1@example.com/">via dup</a>]</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_17_0@example.com/">test_0_17_0: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1548723600000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_17_2@example.com/">duplicate: https://lore.kernel.org/lkml/regzbot-testing-test_0_17_1@example.com</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1548896400000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_17_0@example.com/">introduced: v1.8..v1.9-rc1</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1548723600000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li></li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_0_17_0@example.com/">https://lore.kernel.org/r/regzbot-testing-test_0_17_0@example.com/</a></li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_0_17_1@example.com/">https://lore.kernel.org/r/regzbot-testing-test_0_17_1@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.8..v1.9-rc1</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>updated title, set by test_0_10_0</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_9_0@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_0_9_0@example.com/">activity</a>: <a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_9_0@example.com/"><script type="text/javascript">timeAgo(1547254800000);</script></a> &amp; <a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_14_0@example.com/"><script type="text/javascript">timeAgo(1547859600000);</script></a>.</div></summary>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_14_0@example.com/">test_0_14_0: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547859600000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_13_0@example.com/">test_0_13_0: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547773200000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_9_2@example.com/">test_0_9_2: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547427600000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_9_1@example.com/">test_0_9_1: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547341200000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_9_0@example.com/">test_0_9_0: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547254800000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_14_0@example.com/">unbackburn</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547859600000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_13_0@example.com/">backburn: Some reason</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547773200000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_11_0@example.com/">poke</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547600400000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_10_0@example.com/">summary: updated title, set by test_0_10_0</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547514000000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_9_2@example.com/">introduced: v1.8..v1.9-rc1</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547427600000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li></li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_0_9_0@example.com/">https://lore.kernel.org/r/regzbot-testing-test_0_9_0@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.8..v1.9-rc1</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_0_8: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/lkml/regzbot-testing-test_0_8@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_0_8@example.com/">activity</a>: <script type="text/javascript">timeAgo(1547168400000);</script>.</div></summary>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/lkml/regzbot-testing-test_0_8@example.com/">test_0_8: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547168400000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/lkml/regzbot-testing-test_0_8@example.com/">introduced: v1.8..v1.9-rc1</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547168400000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li></li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_0_8@example.com/">https://lore.kernel.org/r/regzbot-testing-test_0_8@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>all others with unknown culprit and activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>on back burner with activity in the past six months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+  </table>
+  <hr>
+  <p style="text-align: center">[compiled by <a href="https://linux-regtracking.leemhuis.info">regzbot</a> on 2019-01-31 01:00:00 (UTC). Wanna know more about regzbot? Then check out its <a href="https://gitlab.com/knurd42/regzbot/-/blob/main/docs/getting_started.md">getting started guide</a> or its <a href="https://gitlab.com/knurd42/regzbot/-/blob/main/docs/reference.md">reference documentation</a>.]</p>
+</body>
+-----END WEB offltest_0_18-----
+
+-----BEGIN WEB offltest_0_19-----
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+</head>
+<body>
+  <script src="../relativetime.js" type="text/javascript"></script>
+  <h1>Linux kernel regression status</h1>
+  <h2><a href="../next/">[next]</a>&nbsp;[mainline]&nbsp;<a href="../stable/">[stable/longterm]</a>&nbsp;•&nbsp;<a href="../new/">[new]</a>&nbsp;•&nbsp;<a href="../all/">[all]</a>&nbsp;•&nbsp;<a href="../resolved/">[resolved]</a>&nbsp;<a href="../inconclusive/">[inconclusive]</a>&nbsp;</h2>
+  <table style="width:100%;">
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>current cycle (v1.10.. aka v1.11-rc), culprit identified</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>current cycle (v1.10.. aka v1.11-rc), unknown culprit</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>previous cycle (v1.9..v1.10), culprit identified, with activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>older cycles (..v1.9), culprit identified, with activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>previous cycle (v1.9..v1.10), unknown culprit, with activity in the past three weeks</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>older cycles (..v1.9), unknown culprit, with activity in the past three weeks</strong>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.8..v1.9-rc1</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_0_19_0: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_19_0@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_0_19_0@example.com/">activity</a>: <a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_19_0@example.com/"><script type="text/javascript">timeAgo(1549155600000);</script></a> &amp; <a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_19_1@example.com/"><script type="text/javascript">timeAgo(1549242000000);</script></a>.</div></summary>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_19_1@example.com/">test_0_19_1: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1549242000000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_19_0@example.com/">test_0_19_0: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1549155600000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_19_1@example.com/">introduced: v1.8..v1.9-rc1</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1549242000000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li></li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_0_19_0@example.com/">https://lore.kernel.org/r/regzbot-testing-test_0_19_0@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.8..v1.9-rc1</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_0_18: Lorem ipsum dolor sit amet</i></strong> by <a href="https://bugzilla.example.com/show_bug.cgi?id=215744">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/generic/https://bugzilla.example.com/show_bug.cgi?id=215744/">activity</a>: <script type="text/javascript">timeAgo(1549069200000);</script>.</div></summary>
+          <p>
+            <ul style="padding-left: 5px; margin-top: -1em;"></ul>
+          </p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_18@example.com/">introduced: v1.8..v1.9-rc1</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1549069200000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li></li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://bugzilla.example.com/show_bug.cgi?id=215744">https://bugzilla.example.com/show_bug.cgi?id=215744</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.8..v1.9-rc1</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_0_17_0: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_17_0@example.com/">Regzbot testingmail</a> and <a href="https://lore.kernel.org/lkml/regzbot-testing-test_0_17_1@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_0_17_1@example.com/">activity</a>: <a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_17_0@example.com/"><script type="text/javascript">timeAgo(1548723600000);</script></a> &amp; <a href="https://lore.kernel.org/lkml/regzbot-testing-test_0_17_3@example.com/"><script type="text/javascript">timeAgo(1548982800000);</script></a>.</div></summary>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/lkml/regzbot-testing-test_0_17_3@example.com/">test_0_17_3: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1548982800000);</script>, by Regzbot testingmail [<a href="../regression/lore/regzbot-testing-test_0_17_1@example.com/">via dup</a>]</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_17_2@example.com/">test_0_17_2: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1548896400000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/lkml/regzbot-testing-test_0_17_1@example.com/">test_0_17_1: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1548810000000);</script>, by Regzbot testingmail [<a href="../regression/lore/regzbot-testing-test_0_17_1@example.com/">via dup</a>]</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_17_0@example.com/">test_0_17_0: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1548723600000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_17_2@example.com/">duplicate: https://lore.kernel.org/lkml/regzbot-testing-test_0_17_1@example.com</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1548896400000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_17_0@example.com/">introduced: v1.8..v1.9-rc1</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1548723600000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li></li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_0_17_0@example.com/">https://lore.kernel.org/r/regzbot-testing-test_0_17_0@example.com/</a></li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_0_17_1@example.com/">https://lore.kernel.org/r/regzbot-testing-test_0_17_1@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.8..v1.9-rc1</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>updated title, set by test_0_10_0</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_9_0@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_0_9_0@example.com/">activity</a>: <a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_9_0@example.com/"><script type="text/javascript">timeAgo(1547254800000);</script></a> &amp; <a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_14_0@example.com/"><script type="text/javascript">timeAgo(1547859600000);</script></a>.</div></summary>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_14_0@example.com/">test_0_14_0: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547859600000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_13_0@example.com/">test_0_13_0: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547773200000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_9_2@example.com/">test_0_9_2: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547427600000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_9_1@example.com/">test_0_9_1: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547341200000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_9_0@example.com/">test_0_9_0: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547254800000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_14_0@example.com/">unbackburn</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547859600000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_13_0@example.com/">backburn: Some reason</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547773200000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_11_0@example.com/">poke</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547600400000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_10_0@example.com/">summary: updated title, set by test_0_10_0</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547514000000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_9_2@example.com/">introduced: v1.8..v1.9-rc1</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547427600000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li></li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_0_9_0@example.com/">https://lore.kernel.org/r/regzbot-testing-test_0_9_0@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.8..v1.9-rc1</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_0_8: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/lkml/regzbot-testing-test_0_8@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_0_8@example.com/">activity</a>: <script type="text/javascript">timeAgo(1547168400000);</script>.</div></summary>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/lkml/regzbot-testing-test_0_8@example.com/">test_0_8: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547168400000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/lkml/regzbot-testing-test_0_8@example.com/">introduced: v1.8..v1.9-rc1</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547168400000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li></li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_0_8@example.com/">https://lore.kernel.org/r/regzbot-testing-test_0_8@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>all others with unknown culprit and activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>on back burner with activity in the past six months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+  </table>
+  <hr>
+  <p style="text-align: center">[compiled by <a href="https://linux-regtracking.leemhuis.info">regzbot</a> on 2019-01-31 01:00:00 (UTC). Wanna know more about regzbot? Then check out its <a href="https://gitlab.com/knurd42/regzbot/-/blob/main/docs/getting_started.md">getting started guide</a> or its <a href="https://gitlab.com/knurd42/regzbot/-/blob/main/docs/reference.md">reference documentation</a>.]</p>
+</body>
+-----END WEB offltest_0_19-----
+
+-----BEGIN WEB offltest_0_20-----
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+</head>
+<body>
+  <script src="../relativetime.js" type="text/javascript"></script>
+  <h1>Linux kernel regression status</h1>
+  <h2><a href="../next/">[next]</a>&nbsp;[mainline]&nbsp;<a href="../stable/">[stable/longterm]</a>&nbsp;•&nbsp;<a href="../new/">[new]</a>&nbsp;•&nbsp;<a href="../all/">[all]</a>&nbsp;•&nbsp;<a href="../resolved/">[resolved]</a>&nbsp;<a href="../inconclusive/">[inconclusive]</a>&nbsp;</h2>
+  <table style="width:100%;">
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>current cycle (v1.10.. aka v1.11-rc), culprit identified</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>current cycle (v1.10.. aka v1.11-rc), unknown culprit</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>previous cycle (v1.9..v1.10), culprit identified, with activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>older cycles (..v1.9), culprit identified, with activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>previous cycle (v1.9..v1.10), unknown culprit, with activity in the past three weeks</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>older cycles (..v1.9), unknown culprit, with activity in the past three weeks</strong>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.8..v1.9-rc1</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_0_19_0: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_19_0@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_0_19_0@example.com/">activity</a>: <a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_19_0@example.com/"><script type="text/javascript">timeAgo(1549155600000);</script></a> &amp; <a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_19_1@example.com/"><script type="text/javascript">timeAgo(1549242000000);</script></a>.</div></summary>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_19_1@example.com/">test_0_19_1: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1549242000000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_19_0@example.com/">test_0_19_0: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1549155600000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_19_1@example.com/">introduced: v1.8..v1.9-rc1</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1549242000000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li></li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_0_19_0@example.com/">https://lore.kernel.org/r/regzbot-testing-test_0_19_0@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.8..v1.9-rc1</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_0_18: Lorem ipsum dolor sit amet</i></strong> by <a href="https://bugzilla.example.com/show_bug.cgi?id=215744">Regzbot testingmail</a> and <a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_20_0@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_0_20_0@example.com/">activity</a>: <script type="text/javascript">timeAgo(1549069200000);</script>.</div></summary>
+          <p>
+            <ul style="padding-left: 5px; margin-top: -1em;"></ul>
+          </p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_18@example.com/">introduced: v1.8..v1.9-rc1</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1549069200000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li></li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://bugzilla.example.com/show_bug.cgi?id=215744">https://bugzilla.example.com/show_bug.cgi?id=215744</a></li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_0_20_0@example.com/">https://lore.kernel.org/r/regzbot-testing-test_0_20_0@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.8..v1.9-rc1</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_0_17_0: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_17_0@example.com/">Regzbot testingmail</a> and <a href="https://lore.kernel.org/lkml/regzbot-testing-test_0_17_1@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_0_17_1@example.com/">activity</a>: <a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_17_0@example.com/"><script type="text/javascript">timeAgo(1548723600000);</script></a> &amp; <a href="https://lore.kernel.org/lkml/regzbot-testing-test_0_17_3@example.com/"><script type="text/javascript">timeAgo(1548982800000);</script></a>.</div></summary>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/lkml/regzbot-testing-test_0_17_3@example.com/">test_0_17_3: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1548982800000);</script>, by Regzbot testingmail [<a href="../regression/lore/regzbot-testing-test_0_17_1@example.com/">via dup</a>]</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_17_2@example.com/">test_0_17_2: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1548896400000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/lkml/regzbot-testing-test_0_17_1@example.com/">test_0_17_1: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1548810000000);</script>, by Regzbot testingmail [<a href="../regression/lore/regzbot-testing-test_0_17_1@example.com/">via dup</a>]</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_17_0@example.com/">test_0_17_0: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1548723600000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_17_2@example.com/">duplicate: https://lore.kernel.org/lkml/regzbot-testing-test_0_17_1@example.com</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1548896400000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_17_0@example.com/">introduced: v1.8..v1.9-rc1</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1548723600000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li></li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_0_17_0@example.com/">https://lore.kernel.org/r/regzbot-testing-test_0_17_0@example.com/</a></li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_0_17_1@example.com/">https://lore.kernel.org/r/regzbot-testing-test_0_17_1@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.8..v1.9-rc1</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>updated title, set by test_0_10_0</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_9_0@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_0_9_0@example.com/">activity</a>: <a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_9_0@example.com/"><script type="text/javascript">timeAgo(1547254800000);</script></a> &amp; <a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_14_0@example.com/"><script type="text/javascript">timeAgo(1547859600000);</script></a>.</div></summary>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_14_0@example.com/">test_0_14_0: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547859600000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_13_0@example.com/">test_0_13_0: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547773200000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_9_2@example.com/">test_0_9_2: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547427600000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_9_1@example.com/">test_0_9_1: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547341200000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_9_0@example.com/">test_0_9_0: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547254800000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_14_0@example.com/">unbackburn</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547859600000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_13_0@example.com/">backburn: Some reason</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547773200000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_11_0@example.com/">poke</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547600400000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_10_0@example.com/">summary: updated title, set by test_0_10_0</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547514000000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_9_2@example.com/">introduced: v1.8..v1.9-rc1</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547427600000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li></li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_0_9_0@example.com/">https://lore.kernel.org/r/regzbot-testing-test_0_9_0@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.8..v1.9-rc1</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_0_8: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/lkml/regzbot-testing-test_0_8@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_0_8@example.com/">activity</a>: <script type="text/javascript">timeAgo(1547168400000);</script>.</div></summary>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/lkml/regzbot-testing-test_0_8@example.com/">test_0_8: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547168400000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/lkml/regzbot-testing-test_0_8@example.com/">introduced: v1.8..v1.9-rc1</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547168400000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li></li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_0_8@example.com/">https://lore.kernel.org/r/regzbot-testing-test_0_8@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>all others with unknown culprit and activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>on back burner with activity in the past six months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+  </table>
+  <hr>
+  <p style="text-align: center">[compiled by <a href="https://linux-regtracking.leemhuis.info">regzbot</a> on 2019-01-31 01:00:00 (UTC). Wanna know more about regzbot? Then check out its <a href="https://gitlab.com/knurd42/regzbot/-/blob/main/docs/getting_started.md">getting started guide</a> or its <a href="https://gitlab.com/knurd42/regzbot/-/blob/main/docs/reference.md">reference documentation</a>.]</p>
+</body>
+-----END WEB offltest_0_20-----
+
+-----BEGIN WEB offltest_0_21-----
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+</head>
+<body>
+  <script src="../relativetime.js" type="text/javascript"></script>
+  <h1>Linux kernel regression status</h1>
+  <h2><a href="../next/">[next]</a>&nbsp;[mainline]&nbsp;<a href="../stable/">[stable/longterm]</a>&nbsp;•&nbsp;<a href="../new/">[new]</a>&nbsp;•&nbsp;<a href="../all/">[all]</a>&nbsp;•&nbsp;<a href="../resolved/">[resolved]</a>&nbsp;<a href="../inconclusive/">[inconclusive]</a>&nbsp;</h2>
+  <table style="width:100%;">
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>current cycle (v1.10.. aka v1.11-rc), culprit identified</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>current cycle (v1.10.. aka v1.11-rc), unknown culprit</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>previous cycle (v1.9..v1.10), culprit identified, with activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>older cycles (..v1.9), culprit identified, with activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>previous cycle (v1.9..v1.10), unknown culprit, with activity in the past three weeks</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>older cycles (..v1.9), unknown culprit, with activity in the past three weeks</strong>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.8..v1.9-rc1</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_0_19_0: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_19_0@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_0_19_0@example.com/">activity</a>: <a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_19_0@example.com/"><script type="text/javascript">timeAgo(1549155600000);</script></a> &amp; <a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_19_1@example.com/"><script type="text/javascript">timeAgo(1549242000000);</script></a>.</div></summary>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_19_1@example.com/">test_0_19_1: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1549242000000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_19_0@example.com/">test_0_19_0: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1549155600000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_19_1@example.com/">introduced: v1.8..v1.9-rc1</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1549242000000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li></li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_0_19_0@example.com/">https://lore.kernel.org/r/regzbot-testing-test_0_19_0@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.8..v1.9-rc1</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_0_18: Lorem ipsum dolor sit amet</i></strong> by <a href="https://bugzilla.example.com/show_bug.cgi?id=215744">Regzbot testingmail</a> and <a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_20_0@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_0_20_0@example.com/">activity</a>: <script type="text/javascript">timeAgo(1549069200000);</script>.</div></summary>
+          <p>
+            <ul style="padding-left: 5px; margin-top: -1em;"></ul>
+          </p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_18@example.com/">introduced: v1.8..v1.9-rc1</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1549069200000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li></li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://bugzilla.example.com/show_bug.cgi?id=215744">https://bugzilla.example.com/show_bug.cgi?id=215744</a></li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_0_20_0@example.com/">https://lore.kernel.org/r/regzbot-testing-test_0_20_0@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.8..v1.9-rc1</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_0_17_0: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_17_0@example.com/">Regzbot testingmail</a> and <a href="https://lore.kernel.org/lkml/regzbot-testing-test_0_17_1@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_0_17_1@example.com/">activity</a>: <a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_17_0@example.com/"><script type="text/javascript">timeAgo(1548723600000);</script></a> &amp; <a href="https://lore.kernel.org/lkml/regzbot-testing-test_0_17_3@example.com/"><script type="text/javascript">timeAgo(1548982800000);</script></a>.</div></summary>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/lkml/regzbot-testing-test_0_17_3@example.com/">test_0_17_3: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1548982800000);</script>, by Regzbot testingmail [<a href="../regression/lore/regzbot-testing-test_0_17_1@example.com/">via dup</a>]</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_17_2@example.com/">test_0_17_2: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1548896400000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/lkml/regzbot-testing-test_0_17_1@example.com/">test_0_17_1: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1548810000000);</script>, by Regzbot testingmail [<a href="../regression/lore/regzbot-testing-test_0_17_1@example.com/">via dup</a>]</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_17_0@example.com/">test_0_17_0: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1548723600000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_17_2@example.com/">duplicate: https://lore.kernel.org/lkml/regzbot-testing-test_0_17_1@example.com</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1548896400000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_17_0@example.com/">introduced: v1.8..v1.9-rc1</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1548723600000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li></li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_0_17_0@example.com/">https://lore.kernel.org/r/regzbot-testing-test_0_17_0@example.com/</a></li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_0_17_1@example.com/">https://lore.kernel.org/r/regzbot-testing-test_0_17_1@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.8..v1.9-rc1</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>updated title, set by test_0_10_0</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_9_0@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_0_9_0@example.com/">activity</a>: <a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_9_0@example.com/"><script type="text/javascript">timeAgo(1547254800000);</script></a> &amp; <a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_14_0@example.com/"><script type="text/javascript">timeAgo(1547859600000);</script></a>.</div></summary>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_14_0@example.com/">test_0_14_0: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547859600000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_13_0@example.com/">test_0_13_0: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547773200000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_9_2@example.com/">test_0_9_2: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547427600000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_9_1@example.com/">test_0_9_1: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547341200000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_9_0@example.com/">test_0_9_0: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547254800000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_14_0@example.com/">unbackburn</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547859600000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_13_0@example.com/">backburn: Some reason</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547773200000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_11_0@example.com/">poke</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547600400000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_10_0@example.com/">summary: updated title, set by test_0_10_0</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547514000000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_9_2@example.com/">introduced: v1.8..v1.9-rc1</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547427600000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li></li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_0_9_0@example.com/">https://lore.kernel.org/r/regzbot-testing-test_0_9_0@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.8..v1.9-rc1</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_0_8: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/lkml/regzbot-testing-test_0_8@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_0_8@example.com/">activity</a>: <script type="text/javascript">timeAgo(1547168400000);</script>.</div></summary>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/lkml/regzbot-testing-test_0_8@example.com/">test_0_8: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547168400000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/lkml/regzbot-testing-test_0_8@example.com/">introduced: v1.8..v1.9-rc1</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547168400000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li></li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_0_8@example.com/">https://lore.kernel.org/r/regzbot-testing-test_0_8@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>all others with unknown culprit and activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>on back burner with activity in the past six months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+  </table>
+  <hr>
+  <p style="text-align: center">[compiled by <a href="https://linux-regtracking.leemhuis.info">regzbot</a> on 2019-01-31 01:00:00 (UTC). Wanna know more about regzbot? Then check out its <a href="https://gitlab.com/knurd42/regzbot/-/blob/main/docs/getting_started.md">getting started guide</a> or its <a href="https://gitlab.com/knurd42/regzbot/-/blob/main/docs/reference.md">reference documentation</a>.]</p>
+</body>
+-----END WEB offltest_0_21-----
+
+-----BEGIN WEB offltest_0_22-----
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+</head>
+<body>
+  <script src="../relativetime.js" type="text/javascript"></script>
+  <h1>Linux kernel regression status</h1>
+  <h2><a href="../next/">[next]</a>&nbsp;[mainline]&nbsp;<a href="../stable/">[stable/longterm]</a>&nbsp;•&nbsp;<a href="../new/">[new]</a>&nbsp;•&nbsp;<a href="../all/">[all]</a>&nbsp;•&nbsp;<a href="../resolved/">[resolved]</a>&nbsp;<a href="../inconclusive/">[inconclusive]</a>&nbsp;</h2>
+  <table style="width:100%;">
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>current cycle (v1.10.. aka v1.11-rc), culprit identified</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>current cycle (v1.10.. aka v1.11-rc), unknown culprit</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>previous cycle (v1.9..v1.10), culprit identified, with activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>older cycles (..v1.9), culprit identified, with activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>previous cycle (v1.9..v1.10), unknown culprit, with activity in the past three weeks</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>older cycles (..v1.9), unknown culprit, with activity in the past three weeks</strong>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.8..v1.9-rc1</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_0_22_0: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_22_0@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_0_22_0@example.com/">activity</a>: <a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_22_0@example.com/"><script type="text/javascript">timeAgo(1549501200000);</script></a> &amp; <a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_22_1@example.com/"><script type="text/javascript">timeAgo(1549587600000);</script></a>.</div></summary>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_22_1@example.com/">test_0_22_1: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1549587600000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_22_0@example.com/">test_0_22_0: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1549501200000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/lkml/regzbot-testing-test_0_22_2@example.com/">introduced: v1.8..v1.9-rc1</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1549674000000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li></li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_0_22_0@example.com/">https://lore.kernel.org/r/regzbot-testing-test_0_22_0@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.8..v1.9-rc1</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_0_19_0: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_19_0@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_0_19_0@example.com/">activity</a>: <a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_19_0@example.com/"><script type="text/javascript">timeAgo(1549155600000);</script></a> &amp; <a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_19_1@example.com/"><script type="text/javascript">timeAgo(1549242000000);</script></a>.</div></summary>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_19_1@example.com/">test_0_19_1: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1549242000000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_19_0@example.com/">test_0_19_0: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1549155600000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_19_1@example.com/">introduced: v1.8..v1.9-rc1</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1549242000000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li></li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_0_19_0@example.com/">https://lore.kernel.org/r/regzbot-testing-test_0_19_0@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.8..v1.9-rc1</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_0_18: Lorem ipsum dolor sit amet</i></strong> by <a href="https://bugzilla.example.com/show_bug.cgi?id=215744">Regzbot testingmail</a> and <a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_20_0@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_0_20_0@example.com/">activity</a>: <script type="text/javascript">timeAgo(1549069200000);</script>.</div></summary>
+          <p>
+            <ul style="padding-left: 5px; margin-top: -1em;"></ul>
+          </p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_18@example.com/">introduced: v1.8..v1.9-rc1</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1549069200000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li></li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://bugzilla.example.com/show_bug.cgi?id=215744">https://bugzilla.example.com/show_bug.cgi?id=215744</a></li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_0_20_0@example.com/">https://lore.kernel.org/r/regzbot-testing-test_0_20_0@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.8..v1.9-rc1</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_0_17_0: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_17_0@example.com/">Regzbot testingmail</a> and <a href="https://lore.kernel.org/lkml/regzbot-testing-test_0_17_1@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_0_17_1@example.com/">activity</a>: <a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_17_0@example.com/"><script type="text/javascript">timeAgo(1548723600000);</script></a> &amp; <a href="https://lore.kernel.org/lkml/regzbot-testing-test_0_17_3@example.com/"><script type="text/javascript">timeAgo(1548982800000);</script></a>.</div></summary>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/lkml/regzbot-testing-test_0_17_3@example.com/">test_0_17_3: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1548982800000);</script>, by Regzbot testingmail [<a href="../regression/lore/regzbot-testing-test_0_17_1@example.com/">via dup</a>]</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_17_2@example.com/">test_0_17_2: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1548896400000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/lkml/regzbot-testing-test_0_17_1@example.com/">test_0_17_1: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1548810000000);</script>, by Regzbot testingmail [<a href="../regression/lore/regzbot-testing-test_0_17_1@example.com/">via dup</a>]</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_17_0@example.com/">test_0_17_0: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1548723600000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_17_2@example.com/">duplicate: https://lore.kernel.org/lkml/regzbot-testing-test_0_17_1@example.com</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1548896400000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_17_0@example.com/">introduced: v1.8..v1.9-rc1</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1548723600000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li></li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_0_17_0@example.com/">https://lore.kernel.org/r/regzbot-testing-test_0_17_0@example.com/</a></li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_0_17_1@example.com/">https://lore.kernel.org/r/regzbot-testing-test_0_17_1@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.8..v1.9-rc1</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>updated title, set by test_0_10_0</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_9_0@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_0_9_0@example.com/">activity</a>: <a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_9_0@example.com/"><script type="text/javascript">timeAgo(1547254800000);</script></a> &amp; <a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_14_0@example.com/"><script type="text/javascript">timeAgo(1547859600000);</script></a>.</div></summary>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_14_0@example.com/">test_0_14_0: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547859600000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_13_0@example.com/">test_0_13_0: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547773200000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_9_2@example.com/">test_0_9_2: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547427600000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_9_1@example.com/">test_0_9_1: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547341200000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_9_0@example.com/">test_0_9_0: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547254800000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_14_0@example.com/">unbackburn</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547859600000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_13_0@example.com/">backburn: Some reason</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547773200000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_11_0@example.com/">poke</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547600400000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_10_0@example.com/">summary: updated title, set by test_0_10_0</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547514000000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_9_2@example.com/">introduced: v1.8..v1.9-rc1</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547427600000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li></li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_0_9_0@example.com/">https://lore.kernel.org/r/regzbot-testing-test_0_9_0@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.8..v1.9-rc1</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_0_8: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/lkml/regzbot-testing-test_0_8@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_0_8@example.com/">activity</a>: <script type="text/javascript">timeAgo(1547168400000);</script>.</div></summary>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/lkml/regzbot-testing-test_0_8@example.com/">test_0_8: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547168400000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/lkml/regzbot-testing-test_0_8@example.com/">introduced: v1.8..v1.9-rc1</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547168400000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li></li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_0_8@example.com/">https://lore.kernel.org/r/regzbot-testing-test_0_8@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>all others with unknown culprit and activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>on back burner with activity in the past six months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+  </table>
+  <hr>
+  <p style="text-align: center">[compiled by <a href="https://linux-regtracking.leemhuis.info">regzbot</a> on 2019-01-31 01:00:00 (UTC). Wanna know more about regzbot? Then check out its <a href="https://gitlab.com/knurd42/regzbot/-/blob/main/docs/getting_started.md">getting started guide</a> or its <a href="https://gitlab.com/knurd42/regzbot/-/blob/main/docs/reference.md">reference documentation</a>.]</p>
+</body>
+-----END WEB offltest_0_22-----
+
+-----BEGIN WEB offltest_0_23-----
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+</head>
+<body>
+  <script src="../relativetime.js" type="text/javascript"></script>
+  <h1>Linux kernel regression status</h1>
+  <h2><a href="../next/">[next]</a>&nbsp;[mainline]&nbsp;<a href="../stable/">[stable/longterm]</a>&nbsp;•&nbsp;<a href="../new/">[new]</a>&nbsp;•&nbsp;<a href="../all/">[all]</a>&nbsp;•&nbsp;<a href="../resolved/">[resolved]</a>&nbsp;<a href="../inconclusive/">[inconclusive]</a>&nbsp;</h2>
+  <table style="width:100%;">
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>current cycle (v1.10.. aka v1.11-rc), culprit identified</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>current cycle (v1.10.. aka v1.11-rc), unknown culprit</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>previous cycle (v1.9..v1.10), culprit identified, with activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>older cycles (..v1.9), culprit identified, with activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>previous cycle (v1.9..v1.10), unknown culprit, with activity in the past three weeks</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>older cycles (..v1.9), unknown culprit, with activity in the past three weeks</strong>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.8..v1.9-rc1</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_0_23_0: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_23_0@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_0_23_0@example.com/">activity</a>: <a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_23_0@example.com/"><script type="text/javascript">timeAgo(1549760400000);</script></a> &amp; <a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_23_3@example.com/"><script type="text/javascript">timeAgo(1550019600000);</script></a>.</div></summary>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_23_3@example.com/">test_0_23_3: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1550019600000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_23_2@example.com/">test_0_23_2: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1549933200000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_23_1@example.com/">test_0_23_1: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1549846800000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_23_0@example.com/">test_0_23_0: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1549760400000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_23_2@example.com/">introduced: v1.8..v1.9-rc1</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1549933200000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li></li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_0_23_0@example.com/">https://lore.kernel.org/r/regzbot-testing-test_0_23_0@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.8..v1.9-rc1</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_0_22_0: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_22_0@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_0_22_0@example.com/">activity</a>: <a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_22_0@example.com/"><script type="text/javascript">timeAgo(1549501200000);</script></a> &amp; <a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_22_1@example.com/"><script type="text/javascript">timeAgo(1549587600000);</script></a>.</div></summary>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_22_1@example.com/">test_0_22_1: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1549587600000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_22_0@example.com/">test_0_22_0: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1549501200000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/lkml/regzbot-testing-test_0_22_2@example.com/">introduced: v1.8..v1.9-rc1</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1549674000000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li></li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_0_22_0@example.com/">https://lore.kernel.org/r/regzbot-testing-test_0_22_0@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.8..v1.9-rc1</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_0_19_0: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_19_0@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_0_19_0@example.com/">activity</a>: <a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_19_0@example.com/"><script type="text/javascript">timeAgo(1549155600000);</script></a> &amp; <a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_19_1@example.com/"><script type="text/javascript">timeAgo(1549242000000);</script></a>.</div></summary>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_19_1@example.com/">test_0_19_1: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1549242000000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_19_0@example.com/">test_0_19_0: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1549155600000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_19_1@example.com/">introduced: v1.8..v1.9-rc1</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1549242000000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li></li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_0_19_0@example.com/">https://lore.kernel.org/r/regzbot-testing-test_0_19_0@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.8..v1.9-rc1</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_0_18: Lorem ipsum dolor sit amet</i></strong> by <a href="https://bugzilla.example.com/show_bug.cgi?id=215744">Regzbot testingmail</a> and <a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_20_0@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_0_20_0@example.com/">activity</a>: <script type="text/javascript">timeAgo(1549069200000);</script>.</div></summary>
+          <p>
+            <ul style="padding-left: 5px; margin-top: -1em;"></ul>
+          </p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_18@example.com/">introduced: v1.8..v1.9-rc1</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1549069200000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li></li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://bugzilla.example.com/show_bug.cgi?id=215744">https://bugzilla.example.com/show_bug.cgi?id=215744</a></li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_0_20_0@example.com/">https://lore.kernel.org/r/regzbot-testing-test_0_20_0@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.8..v1.9-rc1</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_0_17_0: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_17_0@example.com/">Regzbot testingmail</a> and <a href="https://lore.kernel.org/lkml/regzbot-testing-test_0_17_1@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_0_17_1@example.com/">activity</a>: <a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_17_0@example.com/"><script type="text/javascript">timeAgo(1548723600000);</script></a> &amp; <a href="https://lore.kernel.org/lkml/regzbot-testing-test_0_17_3@example.com/"><script type="text/javascript">timeAgo(1548982800000);</script></a>.</div></summary>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/lkml/regzbot-testing-test_0_17_3@example.com/">test_0_17_3: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1548982800000);</script>, by Regzbot testingmail [<a href="../regression/lore/regzbot-testing-test_0_17_1@example.com/">via dup</a>]</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_17_2@example.com/">test_0_17_2: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1548896400000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/lkml/regzbot-testing-test_0_17_1@example.com/">test_0_17_1: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1548810000000);</script>, by Regzbot testingmail [<a href="../regression/lore/regzbot-testing-test_0_17_1@example.com/">via dup</a>]</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_17_0@example.com/">test_0_17_0: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1548723600000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_17_2@example.com/">duplicate: https://lore.kernel.org/lkml/regzbot-testing-test_0_17_1@example.com</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1548896400000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_17_0@example.com/">introduced: v1.8..v1.9-rc1</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1548723600000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li></li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_0_17_0@example.com/">https://lore.kernel.org/r/regzbot-testing-test_0_17_0@example.com/</a></li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_0_17_1@example.com/">https://lore.kernel.org/r/regzbot-testing-test_0_17_1@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.8..v1.9-rc1</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>updated title, set by test_0_10_0</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_9_0@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_0_9_0@example.com/">activity</a>: <a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_9_0@example.com/"><script type="text/javascript">timeAgo(1547254800000);</script></a> &amp; <a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_14_0@example.com/"><script type="text/javascript">timeAgo(1547859600000);</script></a>.</div></summary>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_14_0@example.com/">test_0_14_0: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547859600000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_13_0@example.com/">test_0_13_0: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547773200000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_9_2@example.com/">test_0_9_2: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547427600000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_9_1@example.com/">test_0_9_1: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547341200000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_9_0@example.com/">test_0_9_0: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547254800000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_14_0@example.com/">unbackburn</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547859600000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_13_0@example.com/">backburn: Some reason</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547773200000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_11_0@example.com/">poke</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547600400000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_10_0@example.com/">summary: updated title, set by test_0_10_0</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547514000000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_0_9_2@example.com/">introduced: v1.8..v1.9-rc1</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547427600000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li></li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_0_9_0@example.com/">https://lore.kernel.org/r/regzbot-testing-test_0_9_0@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.8..v1.9-rc1</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_0_8: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/lkml/regzbot-testing-test_0_8@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_0_8@example.com/">activity</a>: <script type="text/javascript">timeAgo(1547168400000);</script>.</div></summary>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/lkml/regzbot-testing-test_0_8@example.com/">test_0_8: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547168400000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/lkml/regzbot-testing-test_0_8@example.com/">introduced: v1.8..v1.9-rc1</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547168400000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li></li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_0_8@example.com/">https://lore.kernel.org/r/regzbot-testing-test_0_8@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>all others with unknown culprit and activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>on back burner with activity in the past six months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+  </table>
+  <hr>
+  <p style="text-align: center">[compiled by <a href="https://linux-regtracking.leemhuis.info">regzbot</a> on 2019-01-31 01:00:00 (UTC). Wanna know more about regzbot? Then check out its <a href="https://gitlab.com/knurd42/regzbot/-/blob/main/docs/getting_started.md">getting started guide</a> or its <a href="https://gitlab.com/knurd42/regzbot/-/blob/main/docs/reference.md">reference documentation</a>.]</p>
+</body>
+-----END WEB offltest_0_23-----
+
+-----BEGIN WEB offltest_1_0-----
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+</head>
+<body>
+  <script src="../relativetime.js" type="text/javascript"></script>
+  <h1>Linux kernel regression status</h1>
+  <h2><a href="../next/">[next]</a>&nbsp;[mainline]&nbsp;<a href="../stable/">[stable/longterm]</a>&nbsp;•&nbsp;<a href="../new/">[new]</a>&nbsp;•&nbsp;<a href="../all/">[all]</a>&nbsp;•&nbsp;<a href="../resolved/">[resolved]</a>&nbsp;<a href="../inconclusive/">[inconclusive]</a>&nbsp;</h2>
+  <table style="width:100%;">
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>current cycle (v1.10.. aka v1.11-rc), culprit identified</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>current cycle (v1.10.. aka v1.11-rc), unknown culprit</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>previous cycle (v1.9..v1.10), culprit identified, with activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>older cycles (..v1.9), culprit identified, with activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>previous cycle (v1.9..v1.10), unknown culprit, with activity in the past three weeks</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>older cycles (..v1.9), unknown culprit, with activity in the past three weeks</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>all others with unknown culprit and activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.8..v1.9-rc1</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_1_0: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_1_0@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_1_0@example.com/">activity</a>: <script type="text/javascript">timeAgo(1546304400000);</script>.</div></summary>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_1_0@example.com/">test_1_0: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546304400000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_1_0@example.com/">introduced: v1.8..v1.9-rc1 ("foo: bar baz")</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546304400000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li></li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_1_0@example.com/">https://lore.kernel.org/r/regzbot-testing-test_1_0@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>on back burner with activity in the past six months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+  </table>
+  <hr>
+  <p style="text-align: center">[compiled by <a href="https://linux-regtracking.leemhuis.info">regzbot</a> on 2019-01-31 01:00:00 (UTC). Wanna know more about regzbot? Then check out its <a href="https://gitlab.com/knurd42/regzbot/-/blob/main/docs/getting_started.md">getting started guide</a> or its <a href="https://gitlab.com/knurd42/regzbot/-/blob/main/docs/reference.md">reference documentation</a>.]</p>
+</body>
+-----END WEB offltest_1_0-----
+
+-----BEGIN WEB offltest_1_1-----
+-----END WEB offltest_1_1-----
+
+-----BEGIN WEB offltest_1_2-----
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+</head>
+<body>
+  <script src="../relativetime.js" type="text/javascript"></script>
+  <h1>Linux kernel regression status</h1>
+  <h2><a href="../next/">[next]</a>&nbsp;[mainline]&nbsp;<a href="../stable/">[stable/longterm]</a>&nbsp;•&nbsp;<a href="../new/">[new]</a>&nbsp;•&nbsp;<a href="../all/">[all]</a>&nbsp;•&nbsp;<a href="../resolved/">[resolved]</a>&nbsp;<a href="../inconclusive/">[inconclusive]</a>&nbsp;</h2>
+  <table style="width:100%;">
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>current cycle (v1.10.. aka v1.11-rc), culprit identified</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>current cycle (v1.10.. aka v1.11-rc), unknown culprit</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>previous cycle (v1.9..v1.10), culprit identified, with activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>older cycles (..v1.9), culprit identified, with activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>previous cycle (v1.9..v1.10), unknown culprit, with activity in the past three weeks</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>older cycles (..v1.9), unknown culprit, with activity in the past three weeks</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>all others with unknown culprit and activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.8..v1.9-rc1</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_1_2_0: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_1_2_0@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_1_2_0@example.com/">activity</a>: <a href="https://lore.kernel.org/regressions/regzbot-testing-test_1_2_0@example.com/"><script type="text/javascript">timeAgo(1546390800000);</script></a> &amp; <a href="https://lore.kernel.org/regressions/regzbot-testing-test_1_2_1@example.com/"><script type="text/javascript">timeAgo(1546477200000);</script></a>. Noteworthy: <mark style="background-color: #D0D0D0;">[<a href="https://lore.kernel.org/regressions/regzbot-testing-test_1_2_1@example.com/">fix incoming</a>]</mark>.</div></summary>
+          <div>
+            <strong>Fix incoming: </strong>
+            <a href="https://lore.kernel.org/regressions/regzbot-testing-test_1_2_1@example.com/">
+              <i>74cdebb9321b</i>
+            </a>
+            <div style="padding-left: 3em;">
+              <script type="text/javascript">timeAgo(1546477200000);</script>
+            </div>
+          </div>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_1_2_1@example.com/">test_1_2_1: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546477200000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_1_2_0@example.com/">test_1_2_0: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546390800000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_1_2_1@example.com/">fix: 74cdebb9321b9b0a3a2b4981b1cec0002b43d124</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546477200000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_1_2_0@example.com/">introduced: v1.8..v1.9-rc1</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546390800000);</script>, by Regzbot testingmail</div></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>on back burner with activity in the past six months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+  </table>
+  <hr>
+  <p style="text-align: center">[compiled by <a href="https://linux-regtracking.leemhuis.info">regzbot</a> on 2019-01-31 01:00:00 (UTC). Wanna know more about regzbot? Then check out its <a href="https://gitlab.com/knurd42/regzbot/-/blob/main/docs/getting_started.md">getting started guide</a> or its <a href="https://gitlab.com/knurd42/regzbot/-/blob/main/docs/reference.md">reference documentation</a>.]</p>
+</body>
+-----END WEB offltest_1_2-----
+
+-----BEGIN WEB offltest_1_3-----
+-----END WEB offltest_1_3-----
+
+-----BEGIN WEB offltest_1_4-----
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+</head>
+<body>
+  <script src="../relativetime.js" type="text/javascript"></script>
+  <h1>Linux kernel regression status</h1>
+  <h2><a href="../next/">[next]</a>&nbsp;[mainline]&nbsp;<a href="../stable/">[stable/longterm]</a>&nbsp;•&nbsp;<a href="../new/">[new]</a>&nbsp;•&nbsp;<a href="../all/">[all]</a>&nbsp;•&nbsp;<a href="../resolved/">[resolved]</a>&nbsp;<a href="../inconclusive/">[inconclusive]</a>&nbsp;</h2>
+  <table style="width:100%;">
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>current cycle (v1.10.. aka v1.11-rc), culprit identified</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>current cycle (v1.10.. aka v1.11-rc), unknown culprit</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>previous cycle (v1.9..v1.10), culprit identified, with activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>older cycles (..v1.9), culprit identified, with activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>previous cycle (v1.9..v1.10), unknown culprit, with activity in the past three weeks</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>older cycles (..v1.9), unknown culprit, with activity in the past three weeks</strong>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.8..v1.9-rc1</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_1_4: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_1_4@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_1_4@example.com/">activity</a>: <a href="https://lore.kernel.org/regressions/regzbot-testing-test_1_4@example.com/"><script type="text/javascript">timeAgo(1546563600000);</script></a> &amp; <a href="https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git/commit/?h=master&amp;id=f524db9faf55e27d6eab690ea6b489599d84b427"><script type="text/javascript">timeAgo(1577836803000);</script></a>. Noteworthy: <mark style="background-color: #D0D0D0;">[<a href="https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git/commit/?h=master&amp;id=f524db9faf55e27d6eab690ea6b489599d84b427">fix incoming</a>]</mark>.</div></summary>
+          <div>
+            <strong>Fix incoming: </strong>
+            <a href="https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git/commit/?h=master&amp;id=f524db9faf55e27d6eab690ea6b489599d84b427">
+              <i>f524db9faf55 ("Testcommit test_1_4")</i>
+            </a>
+            <div style="padding-left: 3em;">
+              <script type="text/javascript">timeAgo(1577836803000);</script>
+            </div>
+          </div>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git/commit/?h=master&amp;id=f524db9faf55e27d6eab690ea6b489599d84b427">Commit f524db9faf55 in next</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1577836803000);</script>, by Regzbot Testing</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_1_4@example.com/">test_1_4: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546563600000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git/commit/?h=master&amp;id=f524db9faf55e27d6eab690ea6b489599d84b427">fix: f524db9faf55 in next referred to this regression</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1577836803000);</script>, by Regzbot Testing</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_1_4@example.com/">introduced: v1.8..v1.9-rc1</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546563600000);</script>, by Regzbot testingmail</div></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>all others with unknown culprit and activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>on back burner with activity in the past six months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+  </table>
+  <hr>
+  <p style="text-align: center">[compiled by <a href="https://linux-regtracking.leemhuis.info">regzbot</a> on 2019-01-31 01:00:00 (UTC). Wanna know more about regzbot? Then check out its <a href="https://gitlab.com/knurd42/regzbot/-/blob/main/docs/getting_started.md">getting started guide</a> or its <a href="https://gitlab.com/knurd42/regzbot/-/blob/main/docs/reference.md">reference documentation</a>.]</p>
+</body>
+-----END WEB offltest_1_4-----
+
+-----BEGIN WEB offltest_1_5-----
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+</head>
+<body>
+  <script src="../relativetime.js" type="text/javascript"></script>
+  <h1>Linux kernel regression status</h1>
+  <h2><a href="../next/">[next]</a>&nbsp;[mainline]&nbsp;<a href="../stable/">[stable/longterm]</a>&nbsp;•&nbsp;<a href="../new/">[new]</a>&nbsp;•&nbsp;<a href="../all/">[all]</a>&nbsp;•&nbsp;<a href="../resolved/">[resolved]</a>&nbsp;<a href="../inconclusive/">[inconclusive]</a>&nbsp;</h2>
+  <table style="width:100%;">
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>current cycle (v1.10.. aka v1.11-rc), culprit identified</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>current cycle (v1.10.. aka v1.11-rc), unknown culprit</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>previous cycle (v1.9..v1.10), culprit identified, with activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>older cycles (..v1.9), culprit identified, with activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>previous cycle (v1.9..v1.10), unknown culprit, with activity in the past three weeks</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>older cycles (..v1.9), unknown culprit, with activity in the past three weeks</strong>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.8..v1.9-rc1</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_1_5: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_1_5@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_1_5@example.com/">activity</a>: <a href="https://lore.kernel.org/regressions/regzbot-testing-test_1_5@example.com/"><script type="text/javascript">timeAgo(1546650000000);</script></a> &amp; <a href="https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?h=linux-1.8.y&amp;id=ed5b7fedcf07bf43186556dfe8b8d5f0356b876c"><script type="text/javascript">timeAgo(1609459203000);</script></a>.</div></summary>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?h=linux-1.8.y&amp;id=ed5b7fedcf07bf43186556dfe8b8d5f0356b876c">Commit ed5b7fedcf07 in stable/linux-1.8.y</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1609459203000);</script>, by Regzbot Testing</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_1_5@example.com/">test_1_5: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546650000000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?h=linux-1.8.y&amp;id=ed5b7fedcf07bf43186556dfe8b8d5f0356b876c">note: ed5b7fedcf07 in stable/linux-1.8.y referred to this regression</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1609459203000);</script>, by Regzbot Testing</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_1_5@example.com/">introduced: v1.8..v1.9-rc1</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546650000000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li></li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_1_5@example.com/">https://lore.kernel.org/r/regzbot-testing-test_1_5@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.8..v1.9-rc1</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_1_4: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_1_4@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_1_4@example.com/">activity</a>: <a href="https://lore.kernel.org/regressions/regzbot-testing-test_1_4@example.com/"><script type="text/javascript">timeAgo(1546563600000);</script></a> &amp; <a href="https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git/commit/?h=master&amp;id=f524db9faf55e27d6eab690ea6b489599d84b427"><script type="text/javascript">timeAgo(1577836803000);</script></a>. Noteworthy: <mark style="background-color: #D0D0D0;">[<a href="https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git/commit/?h=master&amp;id=f524db9faf55e27d6eab690ea6b489599d84b427">fix incoming</a>]</mark>.</div></summary>
+          <div>
+            <strong>Fix incoming: </strong>
+            <a href="https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git/commit/?h=master&amp;id=f524db9faf55e27d6eab690ea6b489599d84b427">
+              <i>f524db9faf55 ("Testcommit test_1_4")</i>
+            </a>
+            <div style="padding-left: 3em;">
+              <script type="text/javascript">timeAgo(1577836803000);</script>
+            </div>
+          </div>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git/commit/?h=master&amp;id=f524db9faf55e27d6eab690ea6b489599d84b427">Commit f524db9faf55 in next</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1577836803000);</script>, by Regzbot Testing</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_1_4@example.com/">test_1_4: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546563600000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git/commit/?h=master&amp;id=f524db9faf55e27d6eab690ea6b489599d84b427">fix: f524db9faf55 in next referred to this regression</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1577836803000);</script>, by Regzbot Testing</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_1_4@example.com/">introduced: v1.8..v1.9-rc1</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546563600000);</script>, by Regzbot testingmail</div></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>all others with unknown culprit and activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>on back burner with activity in the past six months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+  </table>
+  <hr>
+  <p style="text-align: center">[compiled by <a href="https://linux-regtracking.leemhuis.info">regzbot</a> on 2019-01-31 01:00:00 (UTC). Wanna know more about regzbot? Then check out its <a href="https://gitlab.com/knurd42/regzbot/-/blob/main/docs/getting_started.md">getting started guide</a> or its <a href="https://gitlab.com/knurd42/regzbot/-/blob/main/docs/reference.md">reference documentation</a>.]</p>
+</body>
+-----END WEB offltest_1_5-----
+
+-----BEGIN WEB offltest_1_6-----
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+</head>
+<body>
+  <script src="../relativetime.js" type="text/javascript"></script>
+  <h1>Linux kernel regression status</h1>
+  <h2><a href="../next/">[next]</a>&nbsp;[mainline]&nbsp;<a href="../stable/">[stable/longterm]</a>&nbsp;•&nbsp;<a href="../new/">[new]</a>&nbsp;•&nbsp;<a href="../all/">[all]</a>&nbsp;•&nbsp;<a href="../resolved/">[resolved]</a>&nbsp;<a href="../inconclusive/">[inconclusive]</a>&nbsp;</h2>
+  <table style="width:100%;">
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>current cycle (v1.10.. aka v1.11-rc), culprit identified</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>current cycle (v1.10.. aka v1.11-rc), unknown culprit</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>previous cycle (v1.9..v1.10), culprit identified, with activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>older cycles (..v1.9), culprit identified, with activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>previous cycle (v1.9..v1.10), unknown culprit, with activity in the past three weeks</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>older cycles (..v1.9), unknown culprit, with activity in the past three weeks</strong>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.8..v1.9-rc1</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_1_5: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_1_5@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_1_5@example.com/">activity</a>: <a href="https://lore.kernel.org/regressions/regzbot-testing-test_1_5@example.com/"><script type="text/javascript">timeAgo(1546650000000);</script></a> &amp; <a href="https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?h=linux-1.8.y&amp;id=ed5b7fedcf07bf43186556dfe8b8d5f0356b876c"><script type="text/javascript">timeAgo(1609459203000);</script></a>.</div></summary>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?h=linux-1.8.y&amp;id=ed5b7fedcf07bf43186556dfe8b8d5f0356b876c">Commit ed5b7fedcf07 in stable/linux-1.8.y</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1609459203000);</script>, by Regzbot Testing</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_1_5@example.com/">test_1_5: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546650000000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?h=linux-1.8.y&amp;id=ed5b7fedcf07bf43186556dfe8b8d5f0356b876c">note: ed5b7fedcf07 in stable/linux-1.8.y referred to this regression</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1609459203000);</script>, by Regzbot Testing</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_1_5@example.com/">introduced: v1.8..v1.9-rc1</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546650000000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li></li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_1_5@example.com/">https://lore.kernel.org/r/regzbot-testing-test_1_5@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.8..v1.9-rc1</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_1_4: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_1_4@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_1_4@example.com/">activity</a>: <a href="https://lore.kernel.org/regressions/regzbot-testing-test_1_4@example.com/"><script type="text/javascript">timeAgo(1546563600000);</script></a> &amp; <a href="https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git/commit/?h=master&amp;id=f524db9faf55e27d6eab690ea6b489599d84b427"><script type="text/javascript">timeAgo(1577836803000);</script></a>. Noteworthy: <mark style="background-color: #D0D0D0;">[<a href="https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git/commit/?h=master&amp;id=f524db9faf55e27d6eab690ea6b489599d84b427">fix incoming</a>]</mark>.</div></summary>
+          <div>
+            <strong>Fix incoming: </strong>
+            <a href="https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git/commit/?h=master&amp;id=f524db9faf55e27d6eab690ea6b489599d84b427">
+              <i>f524db9faf55 ("Testcommit test_1_4")</i>
+            </a>
+            <div style="padding-left: 3em;">
+              <script type="text/javascript">timeAgo(1577836803000);</script>
+            </div>
+          </div>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git/commit/?h=master&amp;id=f524db9faf55e27d6eab690ea6b489599d84b427">Commit f524db9faf55 in next</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1577836803000);</script>, by Regzbot Testing</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_1_4@example.com/">test_1_4: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546563600000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git/commit/?h=master&amp;id=f524db9faf55e27d6eab690ea6b489599d84b427">fix: f524db9faf55 in next referred to this regression</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1577836803000);</script>, by Regzbot Testing</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_1_4@example.com/">introduced: v1.8..v1.9-rc1</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546563600000);</script>, by Regzbot testingmail</div></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>all others with unknown culprit and activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>on back burner with activity in the past six months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+  </table>
+  <hr>
+  <p style="text-align: center">[compiled by <a href="https://linux-regtracking.leemhuis.info">regzbot</a> on 2019-01-31 01:00:00 (UTC). Wanna know more about regzbot? Then check out its <a href="https://gitlab.com/knurd42/regzbot/-/blob/main/docs/getting_started.md">getting started guide</a> or its <a href="https://gitlab.com/knurd42/regzbot/-/blob/main/docs/reference.md">reference documentation</a>.]</p>
+</body>
+-----END WEB offltest_1_6-----
+
+-----BEGIN WEB offltest_1_7-----
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+</head>
+<body>
+  <script src="../relativetime.js" type="text/javascript"></script>
+  <h1>Linux kernel regression status</h1>
+  <h2><a href="../next/">[next]</a>&nbsp;[mainline]&nbsp;<a href="../stable/">[stable/longterm]</a>&nbsp;•&nbsp;<a href="../new/">[new]</a>&nbsp;•&nbsp;<a href="../all/">[all]</a>&nbsp;•&nbsp;<a href="../resolved/">[resolved]</a>&nbsp;<a href="../inconclusive/">[inconclusive]</a>&nbsp;</h2>
+  <table style="width:100%;">
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>current cycle (v1.10.. aka v1.11-rc), culprit identified</strong>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>
+            <a href="https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?h=master&amp;id=74cdebb9321b9b0a3a2b4981b1cec0002b43d124">74cdebb9321b</a>
+          </li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_1_7: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_1_7@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_1_7@example.com/">activity</a>: <script type="text/javascript">timeAgo(1546736400000);</script>.</div></summary>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_1_7@example.com/">test_1_7: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546736400000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?h=master&amp;id=f1e96749c4e872fd8f217d0d6529bcc308560d72">note: 'f1e96749c4e8' in 'mainline' contains a 'Fixes:' tag for the culprit of this regression</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546736401000);</script>, by Regzbot Testing</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_1_7@example.com/">introduced: 74cdebb9321b9b0a3a2b4981b1cec0002b43d124</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546736400000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li>Fixes: 74cdebb9321b ("This is a mainline_master commit for testing regzbot, the content doesn't matter.")</li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_1_7@example.com/">https://lore.kernel.org/r/regzbot-testing-test_1_7@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>current cycle (v1.10.. aka v1.11-rc), unknown culprit</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>previous cycle (v1.9..v1.10), culprit identified, with activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>older cycles (..v1.9), culprit identified, with activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>previous cycle (v1.9..v1.10), unknown culprit, with activity in the past three weeks</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>older cycles (..v1.9), unknown culprit, with activity in the past three weeks</strong>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.8..v1.9-rc1</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_1_5: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_1_5@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_1_5@example.com/">activity</a>: <a href="https://lore.kernel.org/regressions/regzbot-testing-test_1_5@example.com/"><script type="text/javascript">timeAgo(1546650000000);</script></a> &amp; <a href="https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?h=linux-1.8.y&amp;id=ed5b7fedcf07bf43186556dfe8b8d5f0356b876c"><script type="text/javascript">timeAgo(1609459203000);</script></a>.</div></summary>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?h=linux-1.8.y&amp;id=ed5b7fedcf07bf43186556dfe8b8d5f0356b876c">Commit ed5b7fedcf07 in stable/linux-1.8.y</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1609459203000);</script>, by Regzbot Testing</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_1_5@example.com/">test_1_5: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546650000000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?h=linux-1.8.y&amp;id=ed5b7fedcf07bf43186556dfe8b8d5f0356b876c">note: ed5b7fedcf07 in stable/linux-1.8.y referred to this regression</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1609459203000);</script>, by Regzbot Testing</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_1_5@example.com/">introduced: v1.8..v1.9-rc1</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546650000000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li></li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_1_5@example.com/">https://lore.kernel.org/r/regzbot-testing-test_1_5@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.8..v1.9-rc1</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_1_4: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_1_4@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_1_4@example.com/">activity</a>: <a href="https://lore.kernel.org/regressions/regzbot-testing-test_1_4@example.com/"><script type="text/javascript">timeAgo(1546563600000);</script></a> &amp; <a href="https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git/commit/?h=master&amp;id=f524db9faf55e27d6eab690ea6b489599d84b427"><script type="text/javascript">timeAgo(1577836803000);</script></a>. Noteworthy: <mark style="background-color: #D0D0D0;">[<a href="https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git/commit/?h=master&amp;id=f524db9faf55e27d6eab690ea6b489599d84b427">fix incoming</a>]</mark>.</div></summary>
+          <div>
+            <strong>Fix incoming: </strong>
+            <a href="https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git/commit/?h=master&amp;id=f524db9faf55e27d6eab690ea6b489599d84b427">
+              <i>f524db9faf55 ("Testcommit test_1_4")</i>
+            </a>
+            <div style="padding-left: 3em;">
+              <script type="text/javascript">timeAgo(1577836803000);</script>
+            </div>
+          </div>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git/commit/?h=master&amp;id=f524db9faf55e27d6eab690ea6b489599d84b427">Commit f524db9faf55 in next</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1577836803000);</script>, by Regzbot Testing</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_1_4@example.com/">test_1_4: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546563600000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git/commit/?h=master&amp;id=f524db9faf55e27d6eab690ea6b489599d84b427">fix: f524db9faf55 in next referred to this regression</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1577836803000);</script>, by Regzbot Testing</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_1_4@example.com/">introduced: v1.8..v1.9-rc1</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546563600000);</script>, by Regzbot testingmail</div></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>all others with unknown culprit and activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>on back burner with activity in the past six months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+  </table>
+  <hr>
+  <p style="text-align: center">[compiled by <a href="https://linux-regtracking.leemhuis.info">regzbot</a> on 2019-01-31 01:00:00 (UTC). Wanna know more about regzbot? Then check out its <a href="https://gitlab.com/knurd42/regzbot/-/blob/main/docs/getting_started.md">getting started guide</a> or its <a href="https://gitlab.com/knurd42/regzbot/-/blob/main/docs/reference.md">reference documentation</a>.]</p>
+</body>
+-----END WEB offltest_1_7-----
+
+-----BEGIN WEB offltest_1_8-----
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+</head>
+<body>
+  <script src="../relativetime.js" type="text/javascript"></script>
+  <h1>Linux kernel regression status</h1>
+  <h2><a href="../next/">[next]</a>&nbsp;[mainline]&nbsp;<a href="../stable/">[stable/longterm]</a>&nbsp;•&nbsp;<a href="../new/">[new]</a>&nbsp;•&nbsp;<a href="../all/">[all]</a>&nbsp;•&nbsp;<a href="../resolved/">[resolved]</a>&nbsp;<a href="../inconclusive/">[inconclusive]</a>&nbsp;</h2>
+  <table style="width:100%;">
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>current cycle (v1.10.. aka v1.11-rc), culprit identified</strong>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>
+            <a href="https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?h=master&amp;id=74cdebb9321b9b0a3a2b4981b1cec0002b43d124">74cdebb9321b</a>
+          </li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_1_7: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_1_7@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_1_7@example.com/">activity</a>: <script type="text/javascript">timeAgo(1546736400000);</script>.</div></summary>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_1_7@example.com/">test_1_7: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546736400000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?h=master&amp;id=f1e96749c4e872fd8f217d0d6529bcc308560d72">note: 'f1e96749c4e8' in 'mainline' contains a 'Fixes:' tag for the culprit of this regression</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546736401000);</script>, by Regzbot Testing</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_1_7@example.com/">introduced: 74cdebb9321b9b0a3a2b4981b1cec0002b43d124</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546736400000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?h=master&amp;id=3fc2b3b65641644653d8c5f3fb041a4135d8a1e9">note: '3fc2b3b65641' in 'mainline' contains a 'Fixes:' tag for the culprit of this regression</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546300814000);</script>, by Regzbot Testing</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li>Fixes: 74cdebb9321b ("This is a mainline_master commit for testing regzbot, the content doesn't matter.")</li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_1_7@example.com/">https://lore.kernel.org/r/regzbot-testing-test_1_7@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>current cycle (v1.10.. aka v1.11-rc), unknown culprit</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>previous cycle (v1.9..v1.10), culprit identified, with activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>older cycles (..v1.9), culprit identified, with activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>previous cycle (v1.9..v1.10), unknown culprit, with activity in the past three weeks</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>older cycles (..v1.9), unknown culprit, with activity in the past three weeks</strong>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.8..v1.9-rc1</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_1_5: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_1_5@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_1_5@example.com/">activity</a>: <a href="https://lore.kernel.org/regressions/regzbot-testing-test_1_5@example.com/"><script type="text/javascript">timeAgo(1546650000000);</script></a> &amp; <a href="https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?h=linux-1.8.y&amp;id=ed5b7fedcf07bf43186556dfe8b8d5f0356b876c"><script type="text/javascript">timeAgo(1609459203000);</script></a>.</div></summary>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?h=linux-1.8.y&amp;id=ed5b7fedcf07bf43186556dfe8b8d5f0356b876c">Commit ed5b7fedcf07 in stable/linux-1.8.y</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1609459203000);</script>, by Regzbot Testing</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_1_5@example.com/">test_1_5: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546650000000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?h=linux-1.8.y&amp;id=ed5b7fedcf07bf43186556dfe8b8d5f0356b876c">note: ed5b7fedcf07 in stable/linux-1.8.y referred to this regression</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1609459203000);</script>, by Regzbot Testing</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_1_5@example.com/">introduced: v1.8..v1.9-rc1</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546650000000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li></li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_1_5@example.com/">https://lore.kernel.org/r/regzbot-testing-test_1_5@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.8..v1.9-rc1</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_1_4: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_1_4@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_1_4@example.com/">activity</a>: <a href="https://lore.kernel.org/regressions/regzbot-testing-test_1_4@example.com/"><script type="text/javascript">timeAgo(1546563600000);</script></a> &amp; <a href="https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git/commit/?h=master&amp;id=f524db9faf55e27d6eab690ea6b489599d84b427"><script type="text/javascript">timeAgo(1577836803000);</script></a>. Noteworthy: <mark style="background-color: #D0D0D0;">[<a href="https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git/commit/?h=master&amp;id=f524db9faf55e27d6eab690ea6b489599d84b427">fix incoming</a>]</mark>.</div></summary>
+          <div>
+            <strong>Fix incoming: </strong>
+            <a href="https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git/commit/?h=master&amp;id=f524db9faf55e27d6eab690ea6b489599d84b427">
+              <i>f524db9faf55 ("Testcommit test_1_4")</i>
+            </a>
+            <div style="padding-left: 3em;">
+              <script type="text/javascript">timeAgo(1577836803000);</script>
+            </div>
+          </div>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git/commit/?h=master&amp;id=f524db9faf55e27d6eab690ea6b489599d84b427">Commit f524db9faf55 in next</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1577836803000);</script>, by Regzbot Testing</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_1_4@example.com/">test_1_4: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546563600000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git/commit/?h=master&amp;id=f524db9faf55e27d6eab690ea6b489599d84b427">fix: f524db9faf55 in next referred to this regression</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1577836803000);</script>, by Regzbot Testing</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_1_4@example.com/">introduced: v1.8..v1.9-rc1</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546563600000);</script>, by Regzbot testingmail</div></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>all others with unknown culprit and activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>on back burner with activity in the past six months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+  </table>
+  <hr>
+  <p style="text-align: center">[compiled by <a href="https://linux-regtracking.leemhuis.info">regzbot</a> on 2019-01-31 01:00:00 (UTC). Wanna know more about regzbot? Then check out its <a href="https://gitlab.com/knurd42/regzbot/-/blob/main/docs/getting_started.md">getting started guide</a> or its <a href="https://gitlab.com/knurd42/regzbot/-/blob/main/docs/reference.md">reference documentation</a>.]</p>
+</body>
+-----END WEB offltest_1_8-----
+
+-----BEGIN WEB offltest_1_9-----
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+</head>
+<body>
+  <script src="../relativetime.js" type="text/javascript"></script>
+  <h1>Linux kernel regression status</h1>
+  <h2><a href="../next/">[next]</a>&nbsp;[mainline]&nbsp;<a href="../stable/">[stable/longterm]</a>&nbsp;•&nbsp;<a href="../new/">[new]</a>&nbsp;•&nbsp;<a href="../all/">[all]</a>&nbsp;•&nbsp;<a href="../resolved/">[resolved]</a>&nbsp;<a href="../inconclusive/">[inconclusive]</a>&nbsp;</h2>
+  <table style="width:100%;">
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>current cycle (v1.10.. aka v1.11-rc), culprit identified</strong>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>
+            <a href="https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?h=master&amp;id=74cdebb9321b9b0a3a2b4981b1cec0002b43d124">74cdebb9321b</a>
+          </li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_1_7: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_1_7@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_1_7@example.com/">activity</a>: <script type="text/javascript">timeAgo(1546736400000);</script>.</div></summary>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_1_7@example.com/">test_1_7: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546736400000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?h=master&amp;id=f1e96749c4e872fd8f217d0d6529bcc308560d72">note: 'f1e96749c4e8' in 'mainline' contains a 'Fixes:' tag for the culprit of this regression</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546736401000);</script>, by Regzbot Testing</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_1_7@example.com/">introduced: 74cdebb9321b9b0a3a2b4981b1cec0002b43d124</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546736400000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?h=master&amp;id=3fc2b3b65641644653d8c5f3fb041a4135d8a1e9">note: '3fc2b3b65641' in 'mainline' contains a 'Fixes:' tag for the culprit of this regression</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546300814000);</script>, by Regzbot Testing</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li>Fixes: 74cdebb9321b ("This is a mainline_master commit for testing regzbot, the content doesn't matter.")</li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_1_7@example.com/">https://lore.kernel.org/r/regzbot-testing-test_1_7@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>current cycle (v1.10.. aka v1.11-rc), unknown culprit</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>previous cycle (v1.9..v1.10), culprit identified, with activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>older cycles (..v1.9), culprit identified, with activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>previous cycle (v1.9..v1.10), unknown culprit, with activity in the past three weeks</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>older cycles (..v1.9), unknown culprit, with activity in the past three weeks</strong>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.8..v1.9-rc1</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_1_5: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_1_5@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_1_5@example.com/">activity</a>: <a href="https://lore.kernel.org/regressions/regzbot-testing-test_1_5@example.com/"><script type="text/javascript">timeAgo(1546650000000);</script></a> &amp; <a href="https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?h=linux-1.8.y&amp;id=ed5b7fedcf07bf43186556dfe8b8d5f0356b876c"><script type="text/javascript">timeAgo(1609459203000);</script></a>.</div></summary>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?h=linux-1.8.y&amp;id=ed5b7fedcf07bf43186556dfe8b8d5f0356b876c">Commit ed5b7fedcf07 in stable/linux-1.8.y</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1609459203000);</script>, by Regzbot Testing</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_1_5@example.com/">test_1_5: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546650000000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?h=linux-1.8.y&amp;id=ed5b7fedcf07bf43186556dfe8b8d5f0356b876c">note: ed5b7fedcf07 in stable/linux-1.8.y referred to this regression</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1609459203000);</script>, by Regzbot Testing</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_1_5@example.com/">introduced: v1.8..v1.9-rc1</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546650000000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li></li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_1_5@example.com/">https://lore.kernel.org/r/regzbot-testing-test_1_5@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.8..v1.9-rc1</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_1_4: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_1_4@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_1_4@example.com/">activity</a>: <a href="https://lore.kernel.org/regressions/regzbot-testing-test_1_4@example.com/"><script type="text/javascript">timeAgo(1546563600000);</script></a> &amp; <a href="https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git/commit/?h=master&amp;id=f524db9faf55e27d6eab690ea6b489599d84b427"><script type="text/javascript">timeAgo(1577836803000);</script></a>. Noteworthy: <mark style="background-color: #D0D0D0;">[<a href="https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git/commit/?h=master&amp;id=f524db9faf55e27d6eab690ea6b489599d84b427">fix incoming</a>]</mark>.</div></summary>
+          <div>
+            <strong>Fix incoming: </strong>
+            <a href="https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git/commit/?h=master&amp;id=f524db9faf55e27d6eab690ea6b489599d84b427">
+              <i>f524db9faf55 ("Testcommit test_1_4")</i>
+            </a>
+            <div style="padding-left: 3em;">
+              <script type="text/javascript">timeAgo(1577836803000);</script>
+            </div>
+          </div>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git/commit/?h=master&amp;id=f524db9faf55e27d6eab690ea6b489599d84b427">Commit f524db9faf55 in next</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1577836803000);</script>, by Regzbot Testing</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_1_4@example.com/">test_1_4: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546563600000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git/commit/?h=master&amp;id=f524db9faf55e27d6eab690ea6b489599d84b427">fix: f524db9faf55 in next referred to this regression</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1577836803000);</script>, by Regzbot Testing</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_1_4@example.com/">introduced: v1.8..v1.9-rc1</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546563600000);</script>, by Regzbot testingmail</div></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>all others with unknown culprit and activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>on back burner with activity in the past six months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+  </table>
+  <hr>
+  <p style="text-align: center">[compiled by <a href="https://linux-regtracking.leemhuis.info">regzbot</a> on 2019-01-31 01:00:00 (UTC). Wanna know more about regzbot? Then check out its <a href="https://gitlab.com/knurd42/regzbot/-/blob/main/docs/getting_started.md">getting started guide</a> or its <a href="https://gitlab.com/knurd42/regzbot/-/blob/main/docs/reference.md">reference documentation</a>.]</p>
+</body>
+-----END WEB offltest_1_9-----
+
+-----BEGIN WEB offltest_1_10-----
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+</head>
+<body>
+  <script src="../relativetime.js" type="text/javascript"></script>
+  <h1>Linux kernel regression status</h1>
+  <h2><a href="../next/">[next]</a>&nbsp;[mainline]&nbsp;<a href="../stable/">[stable/longterm]</a>&nbsp;•&nbsp;<a href="../new/">[new]</a>&nbsp;•&nbsp;<a href="../all/">[all]</a>&nbsp;•&nbsp;<a href="../resolved/">[resolved]</a>&nbsp;<a href="../inconclusive/">[inconclusive]</a>&nbsp;</h2>
+  <table style="width:100%;">
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>current cycle (v1.10.. aka v1.11-rc), culprit identified</strong>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>
+            <a href="https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?h=master&amp;id=74cdebb9321b9b0a3a2b4981b1cec0002b43d124">74cdebb9321b</a>
+          </li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_1_7: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_1_7@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_1_7@example.com/">activity</a>: <script type="text/javascript">timeAgo(1546736400000);</script>.</div></summary>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_1_7@example.com/">test_1_7: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546736400000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?h=master&amp;id=f1e96749c4e872fd8f217d0d6529bcc308560d72">note: 'f1e96749c4e8' in 'mainline' contains a 'Fixes:' tag for the culprit of this regression</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546736401000);</script>, by Regzbot Testing</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_1_7@example.com/">introduced: 74cdebb9321b9b0a3a2b4981b1cec0002b43d124</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546736400000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?h=master&amp;id=3fc2b3b65641644653d8c5f3fb041a4135d8a1e9">note: '3fc2b3b65641' in 'mainline' contains a 'Fixes:' tag for the culprit of this regression</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546300814000);</script>, by Regzbot Testing</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li>Fixes: 74cdebb9321b ("This is a mainline_master commit for testing regzbot, the content doesn't matter.")</li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_1_7@example.com/">https://lore.kernel.org/r/regzbot-testing-test_1_7@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>current cycle (v1.10.. aka v1.11-rc), unknown culprit</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>previous cycle (v1.9..v1.10), culprit identified, with activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>older cycles (..v1.9), culprit identified, with activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>previous cycle (v1.9..v1.10), unknown culprit, with activity in the past three weeks</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>older cycles (..v1.9), unknown culprit, with activity in the past three weeks</strong>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.8..v1.9-rc1</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_1_5: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_1_5@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_1_5@example.com/">activity</a>: <a href="https://lore.kernel.org/regressions/regzbot-testing-test_1_5@example.com/"><script type="text/javascript">timeAgo(1546650000000);</script></a> &amp; <a href="https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?h=linux-1.8.y&amp;id=ed5b7fedcf07bf43186556dfe8b8d5f0356b876c"><script type="text/javascript">timeAgo(1609459203000);</script></a>.</div></summary>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?h=linux-1.8.y&amp;id=ed5b7fedcf07bf43186556dfe8b8d5f0356b876c">Commit ed5b7fedcf07 in stable/linux-1.8.y</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1609459203000);</script>, by Regzbot Testing</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_1_5@example.com/">test_1_5: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546650000000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?h=linux-1.8.y&amp;id=ed5b7fedcf07bf43186556dfe8b8d5f0356b876c">note: ed5b7fedcf07 in stable/linux-1.8.y referred to this regression</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1609459203000);</script>, by Regzbot Testing</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_1_5@example.com/">introduced: v1.8..v1.9-rc1</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546650000000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li></li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_1_5@example.com/">https://lore.kernel.org/r/regzbot-testing-test_1_5@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.8..v1.9-rc1</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_1_4: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_1_4@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_1_4@example.com/">activity</a>: <a href="https://lore.kernel.org/regressions/regzbot-testing-test_1_4@example.com/"><script type="text/javascript">timeAgo(1546563600000);</script></a> &amp; <a href="https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git/commit/?h=master&amp;id=f524db9faf55e27d6eab690ea6b489599d84b427"><script type="text/javascript">timeAgo(1577836803000);</script></a>. Noteworthy: <mark style="background-color: #D0D0D0;">[<a href="https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git/commit/?h=master&amp;id=f524db9faf55e27d6eab690ea6b489599d84b427">fix incoming</a>]</mark>.</div></summary>
+          <div>
+            <strong>Fix incoming: </strong>
+            <a href="https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git/commit/?h=master&amp;id=f524db9faf55e27d6eab690ea6b489599d84b427">
+              <i>f524db9faf55 ("Testcommit test_1_4")</i>
+            </a>
+            <div style="padding-left: 3em;">
+              <script type="text/javascript">timeAgo(1577836803000);</script>
+            </div>
+          </div>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git/commit/?h=master&amp;id=f524db9faf55e27d6eab690ea6b489599d84b427">Commit f524db9faf55 in next</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1577836803000);</script>, by Regzbot Testing</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_1_4@example.com/">test_1_4: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546563600000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git/commit/?h=master&amp;id=f524db9faf55e27d6eab690ea6b489599d84b427">fix: f524db9faf55 in next referred to this regression</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1577836803000);</script>, by Regzbot Testing</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_1_4@example.com/">introduced: v1.8..v1.9-rc1</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546563600000);</script>, by Regzbot testingmail</div></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>all others with unknown culprit and activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>on back burner with activity in the past six months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+  </table>
+  <hr>
+  <p style="text-align: center">[compiled by <a href="https://linux-regtracking.leemhuis.info">regzbot</a> on 2019-01-31 01:00:00 (UTC). Wanna know more about regzbot? Then check out its <a href="https://gitlab.com/knurd42/regzbot/-/blob/main/docs/getting_started.md">getting started guide</a> or its <a href="https://gitlab.com/knurd42/regzbot/-/blob/main/docs/reference.md">reference documentation</a>.]</p>
+</body>
+-----END WEB offltest_1_10-----
+
+-----BEGIN WEB offltest_1_11-----
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+</head>
+<body>
+  <script src="../relativetime.js" type="text/javascript"></script>
+  <h1>Linux kernel regression status</h1>
+  <h2><a href="../next/">[next]</a>&nbsp;[mainline]&nbsp;<a href="../stable/">[stable/longterm]</a>&nbsp;•&nbsp;<a href="../new/">[new]</a>&nbsp;•&nbsp;<a href="../all/">[all]</a>&nbsp;•&nbsp;<a href="../resolved/">[resolved]</a>&nbsp;<a href="../inconclusive/">[inconclusive]</a>&nbsp;</h2>
+  <table style="width:100%;">
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>current cycle (v1.10.. aka v1.11-rc), culprit identified</strong>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>
+            <a href="https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?h=master&amp;id=74cdebb9321b9b0a3a2b4981b1cec0002b43d124">74cdebb9321b</a>
+          </li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_1_7: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_1_7@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_1_7@example.com/">activity</a>: <script type="text/javascript">timeAgo(1546736400000);</script>.</div></summary>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_1_7@example.com/">test_1_7: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546736400000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?h=master&amp;id=f1e96749c4e872fd8f217d0d6529bcc308560d72">note: 'f1e96749c4e8' in 'mainline' contains a 'Fixes:' tag for the culprit of this regression</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546736401000);</script>, by Regzbot Testing</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_1_7@example.com/">introduced: 74cdebb9321b9b0a3a2b4981b1cec0002b43d124</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546736400000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?h=master&amp;id=3fc2b3b65641644653d8c5f3fb041a4135d8a1e9">note: '3fc2b3b65641' in 'mainline' contains a 'Fixes:' tag for the culprit of this regression</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546300814000);</script>, by Regzbot Testing</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li>Fixes: 74cdebb9321b ("This is a mainline_master commit for testing regzbot, the content doesn't matter.")</li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_1_7@example.com/">https://lore.kernel.org/r/regzbot-testing-test_1_7@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>current cycle (v1.10.. aka v1.11-rc), unknown culprit</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>previous cycle (v1.9..v1.10), culprit identified, with activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>older cycles (..v1.9), culprit identified, with activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>previous cycle (v1.9..v1.10), unknown culprit, with activity in the past three weeks</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>older cycles (..v1.9), unknown culprit, with activity in the past three weeks</strong>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.8..v1.9-rc1</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_1_5: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_1_5@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_1_5@example.com/">activity</a>: <a href="https://lore.kernel.org/regressions/regzbot-testing-test_1_5@example.com/"><script type="text/javascript">timeAgo(1546650000000);</script></a> &amp; <a href="https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?h=linux-1.8.y&amp;id=ed5b7fedcf07bf43186556dfe8b8d5f0356b876c"><script type="text/javascript">timeAgo(1609459203000);</script></a>.</div></summary>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?h=linux-1.8.y&amp;id=ed5b7fedcf07bf43186556dfe8b8d5f0356b876c">Commit ed5b7fedcf07 in stable/linux-1.8.y</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1609459203000);</script>, by Regzbot Testing</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_1_5@example.com/">test_1_5: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546650000000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?h=linux-1.8.y&amp;id=ed5b7fedcf07bf43186556dfe8b8d5f0356b876c">note: ed5b7fedcf07 in stable/linux-1.8.y referred to this regression</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1609459203000);</script>, by Regzbot Testing</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_1_5@example.com/">introduced: v1.8..v1.9-rc1</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546650000000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li></li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_1_5@example.com/">https://lore.kernel.org/r/regzbot-testing-test_1_5@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.8..v1.9-rc1</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_1_4: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_1_4@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_1_4@example.com/">activity</a>: <a href="https://lore.kernel.org/regressions/regzbot-testing-test_1_4@example.com/"><script type="text/javascript">timeAgo(1546563600000);</script></a> &amp; <a href="https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git/commit/?h=master&amp;id=f524db9faf55e27d6eab690ea6b489599d84b427"><script type="text/javascript">timeAgo(1577836803000);</script></a>. Noteworthy: <mark style="background-color: #D0D0D0;">[<a href="https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git/commit/?h=master&amp;id=f524db9faf55e27d6eab690ea6b489599d84b427">fix incoming</a>]</mark>.</div></summary>
+          <div>
+            <strong>Fix incoming: </strong>
+            <a href="https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git/commit/?h=master&amp;id=f524db9faf55e27d6eab690ea6b489599d84b427">
+              <i>f524db9faf55 ("Testcommit test_1_4")</i>
+            </a>
+            <div style="padding-left: 3em;">
+              <script type="text/javascript">timeAgo(1577836803000);</script>
+            </div>
+          </div>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git/commit/?h=master&amp;id=f524db9faf55e27d6eab690ea6b489599d84b427">Commit f524db9faf55 in next</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1577836803000);</script>, by Regzbot Testing</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_1_4@example.com/">test_1_4: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546563600000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git/commit/?h=master&amp;id=f524db9faf55e27d6eab690ea6b489599d84b427">fix: f524db9faf55 in next referred to this regression</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1577836803000);</script>, by Regzbot Testing</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_1_4@example.com/">introduced: v1.8..v1.9-rc1</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546563600000);</script>, by Regzbot testingmail</div></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>all others with unknown culprit and activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>on back burner with activity in the past six months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+  </table>
+  <hr>
+  <p style="text-align: center">[compiled by <a href="https://linux-regtracking.leemhuis.info">regzbot</a> on 2019-01-31 01:00:00 (UTC). Wanna know more about regzbot? Then check out its <a href="https://gitlab.com/knurd42/regzbot/-/blob/main/docs/getting_started.md">getting started guide</a> or its <a href="https://gitlab.com/knurd42/regzbot/-/blob/main/docs/reference.md">reference documentation</a>.]</p>
+</body>
+-----END WEB offltest_1_11-----
+
+-----BEGIN WEB offltest_1_12-----
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+</head>
+<body>
+  <script src="../relativetime.js" type="text/javascript"></script>
+  <h1>Linux kernel regression status</h1>
+  <h2><a href="../next/">[next]</a>&nbsp;[mainline]&nbsp;<a href="../stable/">[stable/longterm]</a>&nbsp;•&nbsp;<a href="../new/">[new]</a>&nbsp;•&nbsp;<a href="../all/">[all]</a>&nbsp;•&nbsp;<a href="../resolved/">[resolved]</a>&nbsp;<a href="../inconclusive/">[inconclusive]</a>&nbsp;</h2>
+  <table style="width:100%;">
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>current cycle (v1.10.. aka v1.11-rc), culprit identified</strong>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>
+            <a href="https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?h=master&amp;id=74cdebb9321b9b0a3a2b4981b1cec0002b43d124">74cdebb9321b</a>
+          </li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_1_7: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_1_7@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_1_7@example.com/">activity</a>: <script type="text/javascript">timeAgo(1546736400000);</script>.</div></summary>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_1_7@example.com/">test_1_7: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546736400000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?h=master&amp;id=f1e96749c4e872fd8f217d0d6529bcc308560d72">note: 'f1e96749c4e8' in 'mainline' contains a 'Fixes:' tag for the culprit of this regression</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546736401000);</script>, by Regzbot Testing</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_1_7@example.com/">introduced: 74cdebb9321b9b0a3a2b4981b1cec0002b43d124</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546736400000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?h=master&amp;id=3fc2b3b65641644653d8c5f3fb041a4135d8a1e9">note: '3fc2b3b65641' in 'mainline' contains a 'Fixes:' tag for the culprit of this regression</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546300814000);</script>, by Regzbot Testing</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li>Fixes: 74cdebb9321b ("This is a mainline_master commit for testing regzbot, the content doesn't matter.")</li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_1_7@example.com/">https://lore.kernel.org/r/regzbot-testing-test_1_7@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>current cycle (v1.10.. aka v1.11-rc), unknown culprit</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>previous cycle (v1.9..v1.10), culprit identified, with activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>older cycles (..v1.9), culprit identified, with activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>previous cycle (v1.9..v1.10), unknown culprit, with activity in the past three weeks</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>older cycles (..v1.9), unknown culprit, with activity in the past three weeks</strong>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.8..v1.9-rc1</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_1_5: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_1_5@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_1_5@example.com/">activity</a>: <a href="https://lore.kernel.org/regressions/regzbot-testing-test_1_5@example.com/"><script type="text/javascript">timeAgo(1546650000000);</script></a> &amp; <a href="https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?h=linux-1.8.y&amp;id=ed5b7fedcf07bf43186556dfe8b8d5f0356b876c"><script type="text/javascript">timeAgo(1609459203000);</script></a>.</div></summary>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?h=linux-1.8.y&amp;id=ed5b7fedcf07bf43186556dfe8b8d5f0356b876c">Commit ed5b7fedcf07 in stable/linux-1.8.y</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1609459203000);</script>, by Regzbot Testing</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_1_5@example.com/">test_1_5: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546650000000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?h=linux-1.8.y&amp;id=ed5b7fedcf07bf43186556dfe8b8d5f0356b876c">note: ed5b7fedcf07 in stable/linux-1.8.y referred to this regression</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1609459203000);</script>, by Regzbot Testing</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_1_5@example.com/">introduced: v1.8..v1.9-rc1</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546650000000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li></li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_1_5@example.com/">https://lore.kernel.org/r/regzbot-testing-test_1_5@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.8..v1.9-rc1</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_1_4: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_1_4@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_1_4@example.com/">activity</a>: <a href="https://lore.kernel.org/regressions/regzbot-testing-test_1_4@example.com/"><script type="text/javascript">timeAgo(1546563600000);</script></a> &amp; <a href="https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git/commit/?h=master&amp;id=f524db9faf55e27d6eab690ea6b489599d84b427"><script type="text/javascript">timeAgo(1577836803000);</script></a>. Noteworthy: <mark style="background-color: #D0D0D0;">[<a href="https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git/commit/?h=master&amp;id=f524db9faf55e27d6eab690ea6b489599d84b427">fix incoming</a>]</mark>.</div></summary>
+          <div>
+            <strong>Fix incoming: </strong>
+            <a href="https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git/commit/?h=master&amp;id=f524db9faf55e27d6eab690ea6b489599d84b427">
+              <i>f524db9faf55 ("Testcommit test_1_4")</i>
+            </a>
+            <div style="padding-left: 3em;">
+              <script type="text/javascript">timeAgo(1577836803000);</script>
+            </div>
+          </div>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git/commit/?h=master&amp;id=f524db9faf55e27d6eab690ea6b489599d84b427">Commit f524db9faf55 in next</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1577836803000);</script>, by Regzbot Testing</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_1_4@example.com/">test_1_4: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546563600000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git/commit/?h=master&amp;id=f524db9faf55e27d6eab690ea6b489599d84b427">fix: f524db9faf55 in next referred to this regression</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1577836803000);</script>, by Regzbot Testing</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_1_4@example.com/">introduced: v1.8..v1.9-rc1</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546563600000);</script>, by Regzbot testingmail</div></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>all others with unknown culprit and activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>on back burner with activity in the past six months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+  </table>
+  <hr>
+  <p style="text-align: center">[compiled by <a href="https://linux-regtracking.leemhuis.info">regzbot</a> on 2019-01-31 01:00:00 (UTC). Wanna know more about regzbot? Then check out its <a href="https://gitlab.com/knurd42/regzbot/-/blob/main/docs/getting_started.md">getting started guide</a> or its <a href="https://gitlab.com/knurd42/regzbot/-/blob/main/docs/reference.md">reference documentation</a>.]</p>
+</body>
+-----END WEB offltest_1_12-----
+
+-----BEGIN WEB offltest_2_0-----
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+</head>
+<body>
+  <script src="../relativetime.js" type="text/javascript"></script>
+  <h1>Linux kernel regression status</h1>
+  <h2><a href="../next/">[next]</a>&nbsp;[mainline]&nbsp;<a href="../stable/">[stable/longterm]</a>&nbsp;•&nbsp;<a href="../new/">[new]</a>&nbsp;•&nbsp;<a href="../all/">[all]</a>&nbsp;•&nbsp;<a href="../resolved/">[resolved]</a>&nbsp;<a href="../inconclusive/">[inconclusive]</a>&nbsp;</h2>
+  <table style="width:100%;">
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>current cycle (v1.10.. aka v1.11-rc), culprit identified</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>current cycle (v1.10.. aka v1.11-rc), unknown culprit</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>previous cycle (v1.9..v1.10), culprit identified, with activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>older cycles (..v1.9), culprit identified, with activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>previous cycle (v1.9..v1.10), unknown culprit, with activity in the past three weeks</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>older cycles (..v1.9), unknown culprit, with activity in the past three weeks</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>all others with unknown culprit and activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.8..v1.9-rc1</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_2_0: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_0@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_2_0@example.com/">activity</a>: <a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_0@example.com/"><script type="text/javascript">timeAgo(1546304400000);</script></a> &amp; <a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_0_1@example.com/"><script type="text/javascript">timeAgo(1546390800000);</script></a>. Noteworthy: <a href="https://www.kernel.org/releases.html">[1]</a>.</div></summary>
+          <div>[1]: <i><a href="https://www.kernel.org/releases.html">Linktitle</a></i><div style="padding-left: 3em;"><script type="text/javascript">timeAgo(1546390800000);</script>, by Regzbot testingmail</div></div>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_0_1@example.com/">test_2_0_1: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546390800000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_0@example.com/">test_2_0: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546304400000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_0_1@example.com/">relatebrief: https://www.kernel.org/releases.html Linktitle</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546390800000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_0@example.com/">introduced: v1.8..v1.9-rc1</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546304400000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li></li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_2_0@example.com/">https://lore.kernel.org/r/regzbot-testing-test_2_0@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>on back burner with activity in the past six months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+  </table>
+  <hr>
+  <p style="text-align: center">[compiled by <a href="https://linux-regtracking.leemhuis.info">regzbot</a> on 2019-01-31 01:00:00 (UTC). Wanna know more about regzbot? Then check out its <a href="https://gitlab.com/knurd42/regzbot/-/blob/main/docs/getting_started.md">getting started guide</a> or its <a href="https://gitlab.com/knurd42/regzbot/-/blob/main/docs/reference.md">reference documentation</a>.]</p>
+</body>
+-----END WEB offltest_2_0-----
+
+-----BEGIN WEB offltest_2_1-----
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+</head>
+<body>
+  <script src="../relativetime.js" type="text/javascript"></script>
+  <h1>Linux kernel regression status</h1>
+  <h2><a href="../next/">[next]</a>&nbsp;[mainline]&nbsp;<a href="../stable/">[stable/longterm]</a>&nbsp;•&nbsp;<a href="../new/">[new]</a>&nbsp;•&nbsp;<a href="../all/">[all]</a>&nbsp;•&nbsp;<a href="../resolved/">[resolved]</a>&nbsp;<a href="../inconclusive/">[inconclusive]</a>&nbsp;</h2>
+  <table style="width:100%;">
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>current cycle (v1.10.. aka v1.11-rc), culprit identified</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>current cycle (v1.10.. aka v1.11-rc), unknown culprit</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>previous cycle (v1.9..v1.10), culprit identified, with activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>older cycles (..v1.9), culprit identified, with activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>previous cycle (v1.9..v1.10), unknown culprit, with activity in the past three weeks</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>older cycles (..v1.9), unknown culprit, with activity in the past three weeks</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>all others with unknown culprit and activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.8..v1.9-rc1</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_2_0: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_0@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_2_0@example.com/">activity</a>: <a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_0@example.com/"><script type="text/javascript">timeAgo(1546304400000);</script></a> &amp; <a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_1@example.com/"><script type="text/javascript">timeAgo(1546477200000);</script></a>. Noteworthy: <a href="https://www.kernel.org/releases.html">[1]</a>.</div></summary>
+          <div>[1]: <i><a href="https://www.kernel.org/releases.html">Updated linktitle</a></i><div style="padding-left: 3em;"><script type="text/javascript">timeAgo(1546477200000);</script>, by Regzbot testingmail</div></div>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_1@example.com/">test_2_1: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546477200000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_0_1@example.com/">test_2_0_1: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546390800000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_0@example.com/">test_2_0: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546304400000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_1@example.com/">relatebrief: https://www.kernel.org/releases.html Updated linktitle</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546477200000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_0_1@example.com/">relatebrief: https://www.kernel.org/releases.html Linktitle</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546390800000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_0@example.com/">introduced: v1.8..v1.9-rc1</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546304400000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li></li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_2_0@example.com/">https://lore.kernel.org/r/regzbot-testing-test_2_0@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>on back burner with activity in the past six months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+  </table>
+  <hr>
+  <p style="text-align: center">[compiled by <a href="https://linux-regtracking.leemhuis.info">regzbot</a> on 2019-01-31 01:00:00 (UTC). Wanna know more about regzbot? Then check out its <a href="https://gitlab.com/knurd42/regzbot/-/blob/main/docs/getting_started.md">getting started guide</a> or its <a href="https://gitlab.com/knurd42/regzbot/-/blob/main/docs/reference.md">reference documentation</a>.]</p>
+</body>
+-----END WEB offltest_2_1-----
+
+-----BEGIN WEB offltest_2_2-----
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+</head>
+<body>
+  <script src="../relativetime.js" type="text/javascript"></script>
+  <h1>Linux kernel regression status</h1>
+  <h2><a href="../next/">[next]</a>&nbsp;[mainline]&nbsp;<a href="../stable/">[stable/longterm]</a>&nbsp;•&nbsp;<a href="../new/">[new]</a>&nbsp;•&nbsp;<a href="../all/">[all]</a>&nbsp;•&nbsp;<a href="../resolved/">[resolved]</a>&nbsp;<a href="../inconclusive/">[inconclusive]</a>&nbsp;</h2>
+  <table style="width:100%;">
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>current cycle (v1.10.. aka v1.11-rc), culprit identified</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>current cycle (v1.10.. aka v1.11-rc), unknown culprit</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>previous cycle (v1.9..v1.10), culprit identified, with activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>older cycles (..v1.9), culprit identified, with activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>previous cycle (v1.9..v1.10), unknown culprit, with activity in the past three weeks</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>older cycles (..v1.9), unknown culprit, with activity in the past three weeks</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>all others with unknown culprit and activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.8..v1.9-rc1</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_2_0: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_0@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_2_0@example.com/">activity</a>: <a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_0@example.com/"><script type="text/javascript">timeAgo(1546304400000);</script></a> &amp; <a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_2@example.com/"><script type="text/javascript">timeAgo(1546563600000);</script></a>.</div></summary>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_2@example.com/">test_2_2: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546563600000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_1@example.com/">test_2_1: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546477200000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_0_1@example.com/">test_2_0_1: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546390800000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_0@example.com/">test_2_0: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546304400000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_2@example.com/">unrelate: https://www.kernel.org/releases.html</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546563600000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_1@example.com/">relatebrief: https://www.kernel.org/releases.html Updated linktitle</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546477200000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_0_1@example.com/">relatebrief: https://www.kernel.org/releases.html Linktitle</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546390800000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_0@example.com/">introduced: v1.8..v1.9-rc1</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546304400000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li></li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_2_0@example.com/">https://lore.kernel.org/r/regzbot-testing-test_2_0@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>on back burner with activity in the past six months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+  </table>
+  <hr>
+  <p style="text-align: center">[compiled by <a href="https://linux-regtracking.leemhuis.info">regzbot</a> on 2019-01-31 01:00:00 (UTC). Wanna know more about regzbot? Then check out its <a href="https://gitlab.com/knurd42/regzbot/-/blob/main/docs/getting_started.md">getting started guide</a> or its <a href="https://gitlab.com/knurd42/regzbot/-/blob/main/docs/reference.md">reference documentation</a>.]</p>
+</body>
+-----END WEB offltest_2_2-----
+
+-----BEGIN WEB offltest_2_3-----
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+</head>
+<body>
+  <script src="../relativetime.js" type="text/javascript"></script>
+  <h1>Linux kernel regression status</h1>
+  <h2><a href="../next/">[next]</a>&nbsp;[mainline]&nbsp;<a href="../stable/">[stable/longterm]</a>&nbsp;•&nbsp;<a href="../new/">[new]</a>&nbsp;•&nbsp;<a href="../all/">[all]</a>&nbsp;•&nbsp;<a href="../resolved/">[resolved]</a>&nbsp;<a href="../inconclusive/">[inconclusive]</a>&nbsp;</h2>
+  <table style="width:100%;">
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>current cycle (v1.10.. aka v1.11-rc), culprit identified</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>current cycle (v1.10.. aka v1.11-rc), unknown culprit</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>previous cycle (v1.9..v1.10), culprit identified, with activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>older cycles (..v1.9), culprit identified, with activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>previous cycle (v1.9..v1.10), unknown culprit, with activity in the past three weeks</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>older cycles (..v1.9), unknown culprit, with activity in the past three weeks</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>all others with unknown culprit and activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.8..v1.9-rc1</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_2_0: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_0@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_2_0@example.com/">activity</a>: <a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_0@example.com/"><script type="text/javascript">timeAgo(1546304400000);</script></a> &amp; <a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_2@example.com/"><script type="text/javascript">timeAgo(1546563600000);</script></a>.</div></summary>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_2@example.com/">test_2_2: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546563600000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_1@example.com/">test_2_1: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546477200000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_0_1@example.com/">test_2_0_1: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546390800000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_0@example.com/">test_2_0: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546304400000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/lkml/regzbot-testing-test_2_3@example.com/">note: https://lore.kernel.org/regressions/regzbot-testing-test_2_0@example.com test_2_3: refer to this regression on another mainling list [implicit due to link]</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546650000000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_2@example.com/">unrelate: https://www.kernel.org/releases.html</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546563600000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_1@example.com/">relatebrief: https://www.kernel.org/releases.html Updated linktitle</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546477200000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_0_1@example.com/">relatebrief: https://www.kernel.org/releases.html Linktitle</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546390800000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_0@example.com/">introduced: v1.8..v1.9-rc1</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546304400000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li></li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_2_0@example.com/">https://lore.kernel.org/r/regzbot-testing-test_2_0@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>on back burner with activity in the past six months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+  </table>
+  <hr>
+  <p style="text-align: center">[compiled by <a href="https://linux-regtracking.leemhuis.info">regzbot</a> on 2019-01-31 01:00:00 (UTC). Wanna know more about regzbot? Then check out its <a href="https://gitlab.com/knurd42/regzbot/-/blob/main/docs/getting_started.md">getting started guide</a> or its <a href="https://gitlab.com/knurd42/regzbot/-/blob/main/docs/reference.md">reference documentation</a>.]</p>
+</body>
+-----END WEB offltest_2_3-----
+
+-----BEGIN WEB offltest_2_4-----
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+</head>
+<body>
+  <script src="../relativetime.js" type="text/javascript"></script>
+  <h1>Linux kernel regression status</h1>
+  <h2><a href="../next/">[next]</a>&nbsp;[mainline]&nbsp;<a href="../stable/">[stable/longterm]</a>&nbsp;•&nbsp;<a href="../new/">[new]</a>&nbsp;•&nbsp;<a href="../all/">[all]</a>&nbsp;•&nbsp;<a href="../resolved/">[resolved]</a>&nbsp;<a href="../inconclusive/">[inconclusive]</a>&nbsp;</h2>
+  <table style="width:100%;">
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>current cycle (v1.10.. aka v1.11-rc), culprit identified</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>current cycle (v1.10.. aka v1.11-rc), unknown culprit</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>previous cycle (v1.9..v1.10), culprit identified, with activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>older cycles (..v1.9), culprit identified, with activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>previous cycle (v1.9..v1.10), unknown culprit, with activity in the past three weeks</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>older cycles (..v1.9), unknown culprit, with activity in the past three weeks</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>all others with unknown culprit and activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.8..v1.9-rc1</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_2_0: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_0@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_2_0@example.com/">activity</a>: <a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_0@example.com/"><script type="text/javascript">timeAgo(1546304400000);</script></a> &amp; <a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_4@example.com/"><script type="text/javascript">timeAgo(1546736400000);</script></a>. Noteworthy: <a href="https://lore.kernel.org/lkml/regzbot-testing-test_2_3@example.com/">[1]</a>.</div></summary>
+          <div>[1]: <i><a href="https://lore.kernel.org/lkml/regzbot-testing-test_2_3@example.com/">test_2_3: refer to this regression on another mainling list</a></i><div style="padding-left: 3em;"><script type="text/javascript">timeAgo(1546736400000);</script>, by Regzbot testingmail (monitored)</div></div>
+          <p>Latest five known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_4@example.com/">test_2_4: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546736400000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/lkml/regzbot-testing-test_2_3@example.com/">test_2_3: refer to this regression on another mainling list</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546650000000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_2@example.com/">test_2_2: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546563600000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_1@example.com/">test_2_1: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546477200000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_0_1@example.com/">test_2_0_1: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546390800000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_4@example.com/">relate: https://lore.kernel.org/lkml/regzbot-testing-test_2_3@example.com</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546736400000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/lkml/regzbot-testing-test_2_3@example.com/">note: https://lore.kernel.org/regressions/regzbot-testing-test_2_0@example.com test_2_3: refer to this regression on another mainling list [implicit due to link]</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546650000000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_2@example.com/">unrelate: https://www.kernel.org/releases.html</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546563600000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_1@example.com/">relatebrief: https://www.kernel.org/releases.html Updated linktitle</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546477200000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_0_1@example.com/">relatebrief: https://www.kernel.org/releases.html Linktitle</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546390800000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_0@example.com/">introduced: v1.8..v1.9-rc1</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546304400000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li></li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_2_0@example.com/">https://lore.kernel.org/r/regzbot-testing-test_2_0@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>on back burner with activity in the past six months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+  </table>
+  <hr>
+  <p style="text-align: center">[compiled by <a href="https://linux-regtracking.leemhuis.info">regzbot</a> on 2019-01-31 01:00:00 (UTC). Wanna know more about regzbot? Then check out its <a href="https://gitlab.com/knurd42/regzbot/-/blob/main/docs/getting_started.md">getting started guide</a> or its <a href="https://gitlab.com/knurd42/regzbot/-/blob/main/docs/reference.md">reference documentation</a>.]</p>
+</body>
+-----END WEB offltest_2_4-----
+
+-----BEGIN WEB offltest_2_5-----
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+</head>
+<body>
+  <script src="../relativetime.js" type="text/javascript"></script>
+  <h1>Linux kernel regression status</h1>
+  <h2><a href="../next/">[next]</a>&nbsp;[mainline]&nbsp;<a href="../stable/">[stable/longterm]</a>&nbsp;•&nbsp;<a href="../new/">[new]</a>&nbsp;•&nbsp;<a href="../all/">[all]</a>&nbsp;•&nbsp;<a href="../resolved/">[resolved]</a>&nbsp;<a href="../inconclusive/">[inconclusive]</a>&nbsp;</h2>
+  <table style="width:100%;">
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>current cycle (v1.10.. aka v1.11-rc), culprit identified</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>current cycle (v1.10.. aka v1.11-rc), unknown culprit</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>previous cycle (v1.9..v1.10), culprit identified, with activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>older cycles (..v1.9), culprit identified, with activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>previous cycle (v1.9..v1.10), unknown culprit, with activity in the past three weeks</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>older cycles (..v1.9), unknown culprit, with activity in the past three weeks</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>all others with unknown culprit and activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.8..v1.9-rc1</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_2_0: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_0@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_2_0@example.com/">activity</a>: <a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_0@example.com/"><script type="text/javascript">timeAgo(1546304400000);</script></a> &amp; <a href="https://lore.kernel.org/lkml/regzbot-testing-test_2_5@example.com/"><script type="text/javascript">timeAgo(1546822800000);</script></a>. Noteworthy: <a href="https://lore.kernel.org/lkml/regzbot-testing-test_2_3@example.com/">[1]</a>.</div></summary>
+          <div>[1]: <i><a href="https://lore.kernel.org/lkml/regzbot-testing-test_2_3@example.com/">test_2_3: refer to this regression on another mainling list</a></i><div style="padding-left: 3em;"><script type="text/javascript">timeAgo(1546736400000);</script>, by Regzbot testingmail (monitored)</div></div>
+          <p>Latest five known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/lkml/regzbot-testing-test_2_5@example.com/">test_2_5: reply to the thread now monitored</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546822800000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_4@example.com/">test_2_4: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546736400000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/lkml/regzbot-testing-test_2_3@example.com/">test_2_3: refer to this regression on another mainling list</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546650000000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_2@example.com/">test_2_2: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546563600000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_1@example.com/">test_2_1: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546477200000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_4@example.com/">relate: https://lore.kernel.org/lkml/regzbot-testing-test_2_3@example.com</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546736400000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/lkml/regzbot-testing-test_2_3@example.com/">note: https://lore.kernel.org/regressions/regzbot-testing-test_2_0@example.com test_2_3: refer to this regression on another mainling list [implicit due to link]</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546650000000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_2@example.com/">unrelate: https://www.kernel.org/releases.html</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546563600000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_1@example.com/">relatebrief: https://www.kernel.org/releases.html Updated linktitle</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546477200000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_0_1@example.com/">relatebrief: https://www.kernel.org/releases.html Linktitle</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546390800000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_0@example.com/">introduced: v1.8..v1.9-rc1</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546304400000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li></li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_2_0@example.com/">https://lore.kernel.org/r/regzbot-testing-test_2_0@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>on back burner with activity in the past six months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+  </table>
+  <hr>
+  <p style="text-align: center">[compiled by <a href="https://linux-regtracking.leemhuis.info">regzbot</a> on 2019-01-31 01:00:00 (UTC). Wanna know more about regzbot? Then check out its <a href="https://gitlab.com/knurd42/regzbot/-/blob/main/docs/getting_started.md">getting started guide</a> or its <a href="https://gitlab.com/knurd42/regzbot/-/blob/main/docs/reference.md">reference documentation</a>.]</p>
+</body>
+-----END WEB offltest_2_5-----
+
+-----BEGIN WEB offltest_2_6-----
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+</head>
+<body>
+  <script src="../relativetime.js" type="text/javascript"></script>
+  <h1>Linux kernel regression status</h1>
+  <h2><a href="../next/">[next]</a>&nbsp;[mainline]&nbsp;<a href="../stable/">[stable/longterm]</a>&nbsp;•&nbsp;<a href="../new/">[new]</a>&nbsp;•&nbsp;<a href="../all/">[all]</a>&nbsp;•&nbsp;<a href="../resolved/">[resolved]</a>&nbsp;<a href="../inconclusive/">[inconclusive]</a>&nbsp;</h2>
+  <table style="width:100%;">
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>current cycle (v1.10.. aka v1.11-rc), culprit identified</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>current cycle (v1.10.. aka v1.11-rc), unknown culprit</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>previous cycle (v1.9..v1.10), culprit identified, with activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>older cycles (..v1.9), culprit identified, with activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>previous cycle (v1.9..v1.10), unknown culprit, with activity in the past three weeks</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>older cycles (..v1.9), unknown culprit, with activity in the past three weeks</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>all others with unknown culprit and activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.8..v1.9-rc1</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>new title set via a monitored thread</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_0@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_2_0@example.com/">activity</a>: <a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_0@example.com/"><script type="text/javascript">timeAgo(1546304400000);</script></a> &amp; <a href="https://lore.kernel.org/lkml/regzbot-testing-test_2_6@example.com/"><script type="text/javascript">timeAgo(1546909200000);</script></a>. Noteworthy: <a href="https://lore.kernel.org/lkml/regzbot-testing-test_2_3@example.com/">[1]</a>.</div></summary>
+          <div>[1]: <i><a href="https://lore.kernel.org/lkml/regzbot-testing-test_2_3@example.com/">test_2_3: refer to this regression on another mainling list</a></i><div style="padding-left: 3em;"><script type="text/javascript">timeAgo(1546736400000);</script>, by Regzbot testingmail (monitored)</div></div>
+          <p>Latest five known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/lkml/regzbot-testing-test_2_6@example.com/">test_2_6: reply to the thread now monitored with a regzbot command</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546909200000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/lkml/regzbot-testing-test_2_5@example.com/">test_2_5: reply to the thread now monitored</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546822800000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_4@example.com/">test_2_4: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546736400000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/lkml/regzbot-testing-test_2_3@example.com/">test_2_3: refer to this regression on another mainling list</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546650000000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_2@example.com/">test_2_2: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546563600000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/lkml/regzbot-testing-test_2_6@example.com/">summary: new title set via a monitored thread</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546909200000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_4@example.com/">relate: https://lore.kernel.org/lkml/regzbot-testing-test_2_3@example.com</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546736400000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/lkml/regzbot-testing-test_2_3@example.com/">note: https://lore.kernel.org/regressions/regzbot-testing-test_2_0@example.com test_2_3: refer to this regression on another mainling list [implicit due to link]</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546650000000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_2@example.com/">unrelate: https://www.kernel.org/releases.html</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546563600000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_1@example.com/">relatebrief: https://www.kernel.org/releases.html Updated linktitle</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546477200000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_0_1@example.com/">relatebrief: https://www.kernel.org/releases.html Linktitle</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546390800000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_0@example.com/">introduced: v1.8..v1.9-rc1</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546304400000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li></li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_2_0@example.com/">https://lore.kernel.org/r/regzbot-testing-test_2_0@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>on back burner with activity in the past six months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+  </table>
+  <hr>
+  <p style="text-align: center">[compiled by <a href="https://linux-regtracking.leemhuis.info">regzbot</a> on 2019-01-31 01:00:00 (UTC). Wanna know more about regzbot? Then check out its <a href="https://gitlab.com/knurd42/regzbot/-/blob/main/docs/getting_started.md">getting started guide</a> or its <a href="https://gitlab.com/knurd42/regzbot/-/blob/main/docs/reference.md">reference documentation</a>.]</p>
+</body>
+-----END WEB offltest_2_6-----
+
+-----BEGIN WEB offltest_2_7-----
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+</head>
+<body>
+  <script src="../relativetime.js" type="text/javascript"></script>
+  <h1>Linux kernel regression status</h1>
+  <h2><a href="../next/">[next]</a>&nbsp;[mainline]&nbsp;<a href="../stable/">[stable/longterm]</a>&nbsp;•&nbsp;<a href="../new/">[new]</a>&nbsp;•&nbsp;<a href="../all/">[all]</a>&nbsp;•&nbsp;<a href="../resolved/">[resolved]</a>&nbsp;<a href="../inconclusive/">[inconclusive]</a>&nbsp;</h2>
+  <table style="width:100%;">
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>current cycle (v1.10.. aka v1.11-rc), culprit identified</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>current cycle (v1.10.. aka v1.11-rc), unknown culprit</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>previous cycle (v1.9..v1.10), culprit identified, with activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>older cycles (..v1.9), culprit identified, with activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>previous cycle (v1.9..v1.10), unknown culprit, with activity in the past three weeks</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>older cycles (..v1.9), unknown culprit, with activity in the past three weeks</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>all others with unknown culprit and activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.8..v1.9-rc1</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>new title set via a monitored thread</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_0@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_2_0@example.com/">activity</a>: <a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_0@example.com/"><script type="text/javascript">timeAgo(1546304400000);</script></a> &amp; <a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_7@example.com/"><script type="text/javascript">timeAgo(1546995600000);</script></a>.</div></summary>
+          <p>Latest five known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_7@example.com/">test_2_7: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546995600000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_4@example.com/">test_2_4: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546736400000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_2@example.com/">test_2_2: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546563600000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_1@example.com/">test_2_1: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546477200000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_0_1@example.com/">test_2_0_1: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546390800000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_7@example.com/">unrelate: https://lore.kernel.org/lkml/regzbot-testing-test_2_3@example.com</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546995600000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/lkml/regzbot-testing-test_2_6@example.com/">summary: new title set via a monitored thread</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546909200000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_4@example.com/">relate: https://lore.kernel.org/lkml/regzbot-testing-test_2_3@example.com</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546736400000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/lkml/regzbot-testing-test_2_3@example.com/">note: https://lore.kernel.org/regressions/regzbot-testing-test_2_0@example.com test_2_3: refer to this regression on another mainling list [implicit due to link]</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546650000000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_2@example.com/">unrelate: https://www.kernel.org/releases.html</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546563600000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_1@example.com/">relatebrief: https://www.kernel.org/releases.html Updated linktitle</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546477200000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_0_1@example.com/">relatebrief: https://www.kernel.org/releases.html Linktitle</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546390800000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_0@example.com/">introduced: v1.8..v1.9-rc1</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546304400000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li></li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_2_0@example.com/">https://lore.kernel.org/r/regzbot-testing-test_2_0@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>on back burner with activity in the past six months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+  </table>
+  <hr>
+  <p style="text-align: center">[compiled by <a href="https://linux-regtracking.leemhuis.info">regzbot</a> on 2019-01-31 01:00:00 (UTC). Wanna know more about regzbot? Then check out its <a href="https://gitlab.com/knurd42/regzbot/-/blob/main/docs/getting_started.md">getting started guide</a> or its <a href="https://gitlab.com/knurd42/regzbot/-/blob/main/docs/reference.md">reference documentation</a>.]</p>
+</body>
+-----END WEB offltest_2_7-----
+
+-----BEGIN WEB offltest_2_8-----
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+</head>
+<body>
+  <script src="../relativetime.js" type="text/javascript"></script>
+  <h1>Linux kernel regression status</h1>
+  <h2><a href="../next/">[next]</a>&nbsp;[mainline]&nbsp;<a href="../stable/">[stable/longterm]</a>&nbsp;•&nbsp;<a href="../new/">[new]</a>&nbsp;•&nbsp;<a href="../all/">[all]</a>&nbsp;•&nbsp;<a href="../resolved/">[resolved]</a>&nbsp;<a href="../inconclusive/">[inconclusive]</a>&nbsp;</h2>
+  <table style="width:100%;">
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>current cycle (v1.10.. aka v1.11-rc), culprit identified</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>current cycle (v1.10.. aka v1.11-rc), unknown culprit</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>previous cycle (v1.9..v1.10), culprit identified, with activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>older cycles (..v1.9), culprit identified, with activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>previous cycle (v1.9..v1.10), unknown culprit, with activity in the past three weeks</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>older cycles (..v1.9), unknown culprit, with activity in the past three weeks</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>all others with unknown culprit and activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.8..v1.9-rc1</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>new title set via a monitored thread</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_0@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_2_0@example.com/">activity</a>: <a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_0@example.com/"><script type="text/javascript">timeAgo(1546304400000);</script></a> &amp; <a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_7@example.com/"><script type="text/javascript">timeAgo(1546995600000);</script></a>.</div></summary>
+          <p>Latest five known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_7@example.com/">test_2_7: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546995600000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_4@example.com/">test_2_4: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546736400000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_2@example.com/">test_2_2: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546563600000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_1@example.com/">test_2_1: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546477200000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_0_1@example.com/">test_2_0_1: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546390800000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_7@example.com/">unrelate: https://lore.kernel.org/lkml/regzbot-testing-test_2_3@example.com</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546995600000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/lkml/regzbot-testing-test_2_6@example.com/">summary: new title set via a monitored thread</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546909200000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_4@example.com/">relate: https://lore.kernel.org/lkml/regzbot-testing-test_2_3@example.com</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546736400000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/lkml/regzbot-testing-test_2_3@example.com/">note: https://lore.kernel.org/regressions/regzbot-testing-test_2_0@example.com test_2_3: refer to this regression on another mainling list [implicit due to link]</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546650000000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_2@example.com/">unrelate: https://www.kernel.org/releases.html</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546563600000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_1@example.com/">relatebrief: https://www.kernel.org/releases.html Updated linktitle</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546477200000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_0_1@example.com/">relatebrief: https://www.kernel.org/releases.html Linktitle</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546390800000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_0@example.com/">introduced: v1.8..v1.9-rc1</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546304400000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li></li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_2_0@example.com/">https://lore.kernel.org/r/regzbot-testing-test_2_0@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>on back burner with activity in the past six months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+  </table>
+  <hr>
+  <p style="text-align: center">[compiled by <a href="https://linux-regtracking.leemhuis.info">regzbot</a> on 2019-01-31 01:00:00 (UTC). Wanna know more about regzbot? Then check out its <a href="https://gitlab.com/knurd42/regzbot/-/blob/main/docs/getting_started.md">getting started guide</a> or its <a href="https://gitlab.com/knurd42/regzbot/-/blob/main/docs/reference.md">reference documentation</a>.]</p>
+</body>
+-----END WEB offltest_2_8-----
+
+-----BEGIN WEB offltest_2_9-----
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+</head>
+<body>
+  <script src="../relativetime.js" type="text/javascript"></script>
+  <h1>Linux kernel regression status</h1>
+  <h2><a href="../next/">[next]</a>&nbsp;[mainline]&nbsp;<a href="../stable/">[stable/longterm]</a>&nbsp;•&nbsp;<a href="../new/">[new]</a>&nbsp;•&nbsp;<a href="../all/">[all]</a>&nbsp;•&nbsp;<a href="../resolved/">[resolved]</a>&nbsp;<a href="../inconclusive/">[inconclusive]</a>&nbsp;</h2>
+  <table style="width:100%;">
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>current cycle (v1.10.. aka v1.11-rc), culprit identified</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>current cycle (v1.10.. aka v1.11-rc), unknown culprit</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>previous cycle (v1.9..v1.10), culprit identified, with activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>older cycles (..v1.9), culprit identified, with activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>previous cycle (v1.9..v1.10), unknown culprit, with activity in the past three weeks</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>older cycles (..v1.9), unknown culprit, with activity in the past three weeks</strong>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.8..v1.9-rc1</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>new title set via a monitored thread</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_0@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_2_0@example.com/">activity</a>: <a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_0@example.com/"><script type="text/javascript">timeAgo(1546304400000);</script></a> &amp; <a href="https://lore.kernel.org/lkml/regzbot-testing-test_2_9@example.com/"><script type="text/javascript">timeAgo(1547168400000);</script></a>. Noteworthy: <a href="https://lore.kernel.org/lkml/regzbot-testing-test_2_9@example.com/">[1]</a>.</div></summary>
+          <div>[1]: <i><a href="https://lore.kernel.org/lkml/regzbot-testing-test_2_9@example.com/">test_2_9: refer to this regression on another mainling list [implicit due to Link/Closes tag]</a></i><div style="padding-left: 3em;"><script type="text/javascript">timeAgo(1547168400000);</script>, by Regzbot testingmail (monitored)</div></div>
+          <p>Latest five known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/lkml/regzbot-testing-test_2_9@example.com/">test_2_9: refer to this regression on another mainling list</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547168400000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_7@example.com/">test_2_7: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546995600000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_4@example.com/">test_2_4: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546736400000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_2@example.com/">test_2_2: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546563600000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_1@example.com/">test_2_1: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546477200000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/lkml/regzbot-testing-test_2_9@example.com/">relate: https://lore.kernel.org/lkml/regzbot-testing-test_2_9@example.com/ test_2_9: refer to this regression on another mainling list [implicit due to Link/Closes tag]</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547168400000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_7@example.com/">unrelate: https://lore.kernel.org/lkml/regzbot-testing-test_2_3@example.com</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546995600000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/lkml/regzbot-testing-test_2_6@example.com/">summary: new title set via a monitored thread</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546909200000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_4@example.com/">relate: https://lore.kernel.org/lkml/regzbot-testing-test_2_3@example.com</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546736400000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/lkml/regzbot-testing-test_2_3@example.com/">note: https://lore.kernel.org/regressions/regzbot-testing-test_2_0@example.com test_2_3: refer to this regression on another mainling list [implicit due to link]</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546650000000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_2@example.com/">unrelate: https://www.kernel.org/releases.html</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546563600000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_1@example.com/">relatebrief: https://www.kernel.org/releases.html Updated linktitle</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546477200000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_0_1@example.com/">relatebrief: https://www.kernel.org/releases.html Linktitle</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546390800000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_0@example.com/">introduced: v1.8..v1.9-rc1</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546304400000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li></li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_2_0@example.com/">https://lore.kernel.org/r/regzbot-testing-test_2_0@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>all others with unknown culprit and activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>on back burner with activity in the past six months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+  </table>
+  <hr>
+  <p style="text-align: center">[compiled by <a href="https://linux-regtracking.leemhuis.info">regzbot</a> on 2019-01-31 01:00:00 (UTC). Wanna know more about regzbot? Then check out its <a href="https://gitlab.com/knurd42/regzbot/-/blob/main/docs/getting_started.md">getting started guide</a> or its <a href="https://gitlab.com/knurd42/regzbot/-/blob/main/docs/reference.md">reference documentation</a>.]</p>
+</body>
+-----END WEB offltest_2_9-----
+
+-----BEGIN WEB offltest_2_10-----
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+</head>
+<body>
+  <script src="../relativetime.js" type="text/javascript"></script>
+  <h1>Linux kernel regression status</h1>
+  <h2><a href="../next/">[next]</a>&nbsp;[mainline]&nbsp;<a href="../stable/">[stable/longterm]</a>&nbsp;•&nbsp;<a href="../new/">[new]</a>&nbsp;•&nbsp;<a href="../all/">[all]</a>&nbsp;•&nbsp;<a href="../resolved/">[resolved]</a>&nbsp;<a href="../inconclusive/">[inconclusive]</a>&nbsp;</h2>
+  <table style="width:100%;">
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>current cycle (v1.10.. aka v1.11-rc), culprit identified</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>current cycle (v1.10.. aka v1.11-rc), unknown culprit</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>previous cycle (v1.9..v1.10), culprit identified, with activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>older cycles (..v1.9), culprit identified, with activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>previous cycle (v1.9..v1.10), unknown culprit, with activity in the past three weeks</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>older cycles (..v1.9), unknown culprit, with activity in the past three weeks</strong>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.8..v1.9-rc1</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>new title set via a monitored thread</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_0@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_2_0@example.com/">activity</a>: <a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_0@example.com/"><script type="text/javascript">timeAgo(1546304400000);</script></a> &amp; <a href="https://lore.kernel.org/lkml/regzbot-testing-test_2_9@example.com/"><script type="text/javascript">timeAgo(1547168400000);</script></a>. Noteworthy: <a href="https://lore.kernel.org/lkml/regzbot-testing-test_2_9@example.com/">[1]</a>.</div></summary>
+          <div>[1]: <i><a href="https://lore.kernel.org/lkml/regzbot-testing-test_2_9@example.com/">test_2_9: refer to this regression on another mainling list [implicit due to Link/Closes tag]</a></i><div style="padding-left: 3em;"><script type="text/javascript">timeAgo(1547168400000);</script>, by Regzbot testingmail (monitored)</div></div>
+          <p>Latest five known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/lkml/regzbot-testing-test_2_9@example.com/">test_2_9: refer to this regression on another mainling list</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547168400000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_7@example.com/">test_2_7: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546995600000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_4@example.com/">test_2_4: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546736400000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_2@example.com/">test_2_2: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546563600000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_1@example.com/">test_2_1: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546477200000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/lkml/regzbot-testing-test_2_9@example.com/">relate: https://lore.kernel.org/lkml/regzbot-testing-test_2_9@example.com/ test_2_9: refer to this regression on another mainling list [implicit due to Link/Closes tag]</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547168400000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_7@example.com/">unrelate: https://lore.kernel.org/lkml/regzbot-testing-test_2_3@example.com</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546995600000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/lkml/regzbot-testing-test_2_6@example.com/">summary: new title set via a monitored thread</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546909200000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_4@example.com/">relate: https://lore.kernel.org/lkml/regzbot-testing-test_2_3@example.com</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546736400000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/lkml/regzbot-testing-test_2_3@example.com/">note: https://lore.kernel.org/regressions/regzbot-testing-test_2_0@example.com test_2_3: refer to this regression on another mainling list [implicit due to link]</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546650000000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_2@example.com/">unrelate: https://www.kernel.org/releases.html</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546563600000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_1@example.com/">relatebrief: https://www.kernel.org/releases.html Updated linktitle</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546477200000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_0_1@example.com/">relatebrief: https://www.kernel.org/releases.html Linktitle</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546390800000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_0@example.com/">introduced: v1.8..v1.9-rc1</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546304400000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li></li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_2_0@example.com/">https://lore.kernel.org/r/regzbot-testing-test_2_0@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>all others with unknown culprit and activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>on back burner with activity in the past six months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+  </table>
+  <hr>
+  <p style="text-align: center">[compiled by <a href="https://linux-regtracking.leemhuis.info">regzbot</a> on 2019-01-31 01:00:00 (UTC). Wanna know more about regzbot? Then check out its <a href="https://gitlab.com/knurd42/regzbot/-/blob/main/docs/getting_started.md">getting started guide</a> or its <a href="https://gitlab.com/knurd42/regzbot/-/blob/main/docs/reference.md">reference documentation</a>.]</p>
+</body>
+-----END WEB offltest_2_10-----
+
+-----BEGIN WEB offltest_2_11-----
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+</head>
+<body>
+  <script src="../relativetime.js" type="text/javascript"></script>
+  <h1>Linux kernel regression status</h1>
+  <h2><a href="../next/">[next]</a>&nbsp;[mainline]&nbsp;<a href="../stable/">[stable/longterm]</a>&nbsp;•&nbsp;<a href="../new/">[new]</a>&nbsp;•&nbsp;<a href="../all/">[all]</a>&nbsp;•&nbsp;<a href="../resolved/">[resolved]</a>&nbsp;<a href="../inconclusive/">[inconclusive]</a>&nbsp;</h2>
+  <table style="width:100%;">
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>current cycle (v1.10.. aka v1.11-rc), culprit identified</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>current cycle (v1.10.. aka v1.11-rc), unknown culprit</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>previous cycle (v1.9..v1.10), culprit identified, with activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>older cycles (..v1.9), culprit identified, with activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>previous cycle (v1.9..v1.10), unknown culprit, with activity in the past three weeks</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>older cycles (..v1.9), unknown culprit, with activity in the past three weeks</strong>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.8..v1.9-rc1</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>new title set via a monitored thread</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_0@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_2_0@example.com/">activity</a>: <a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_0@example.com/"><script type="text/javascript">timeAgo(1546304400000);</script></a> &amp; <a href="https://lore.kernel.org/lkml/regzbot-testing-test_2_9@example.com/"><script type="text/javascript">timeAgo(1547168400000);</script></a>. Noteworthy: <a href="https://lore.kernel.org/lkml/regzbot-testing-test_2_9@example.com/">[1]</a>.</div></summary>
+          <div>[1]: <i><a href="https://lore.kernel.org/lkml/regzbot-testing-test_2_9@example.com/">test_2_9: refer to this regression on another mainling list [implicit due to Link/Closes tag]</a></i><div style="padding-left: 3em;"><script type="text/javascript">timeAgo(1547168400000);</script>, by Regzbot testingmail (monitored)</div></div>
+          <p>Latest five known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/lkml/regzbot-testing-test_2_9@example.com/">test_2_9: refer to this regression on another mainling list</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547168400000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_7@example.com/">test_2_7: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546995600000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_4@example.com/">test_2_4: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546736400000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_2@example.com/">test_2_2: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546563600000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_1@example.com/">test_2_1: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546477200000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/lkml/regzbot-testing-test_2_9@example.com/">relate: https://lore.kernel.org/lkml/regzbot-testing-test_2_9@example.com/ test_2_9: refer to this regression on another mainling list [implicit due to Link/Closes tag]</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547168400000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_7@example.com/">unrelate: https://lore.kernel.org/lkml/regzbot-testing-test_2_3@example.com</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546995600000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/lkml/regzbot-testing-test_2_6@example.com/">summary: new title set via a monitored thread</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546909200000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_4@example.com/">relate: https://lore.kernel.org/lkml/regzbot-testing-test_2_3@example.com</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546736400000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/lkml/regzbot-testing-test_2_3@example.com/">note: https://lore.kernel.org/regressions/regzbot-testing-test_2_0@example.com test_2_3: refer to this regression on another mainling list [implicit due to link]</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546650000000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_2@example.com/">unrelate: https://www.kernel.org/releases.html</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546563600000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_1@example.com/">relatebrief: https://www.kernel.org/releases.html Updated linktitle</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546477200000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_0_1@example.com/">relatebrief: https://www.kernel.org/releases.html Linktitle</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546390800000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_0@example.com/">introduced: v1.8..v1.9-rc1</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546304400000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li></li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_2_0@example.com/">https://lore.kernel.org/r/regzbot-testing-test_2_0@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>all others with unknown culprit and activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>on back burner with activity in the past six months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+  </table>
+  <hr>
+  <p style="text-align: center">[compiled by <a href="https://linux-regtracking.leemhuis.info">regzbot</a> on 2019-01-31 01:00:00 (UTC). Wanna know more about regzbot? Then check out its <a href="https://gitlab.com/knurd42/regzbot/-/blob/main/docs/getting_started.md">getting started guide</a> or its <a href="https://gitlab.com/knurd42/regzbot/-/blob/main/docs/reference.md">reference documentation</a>.]</p>
+</body>
+-----END WEB offltest_2_11-----
+
+-----BEGIN WEB offltest_2_12-----
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+</head>
+<body>
+  <script src="../relativetime.js" type="text/javascript"></script>
+  <h1>Linux kernel regression status</h1>
+  <h2><a href="../next/">[next]</a>&nbsp;[mainline]&nbsp;<a href="../stable/">[stable/longterm]</a>&nbsp;•&nbsp;<a href="../new/">[new]</a>&nbsp;•&nbsp;<a href="../all/">[all]</a>&nbsp;•&nbsp;<a href="../resolved/">[resolved]</a>&nbsp;<a href="../inconclusive/">[inconclusive]</a>&nbsp;</h2>
+  <table style="width:100%;">
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>current cycle (v1.10.. aka v1.11-rc), culprit identified</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>current cycle (v1.10.. aka v1.11-rc), unknown culprit</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>previous cycle (v1.9..v1.10), culprit identified, with activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>older cycles (..v1.9), culprit identified, with activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>previous cycle (v1.9..v1.10), unknown culprit, with activity in the past three weeks</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>older cycles (..v1.9), unknown culprit, with activity in the past three weeks</strong>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.8..v1.9-rc1</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;"><summary style="list-style-position: outside;"><strong><i>new title set via a monitored thread</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_0@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_2_0@example.com/">activity</a>: <a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_0@example.com/"><script type="text/javascript">timeAgo(1546304400000);</script></a> &amp; <a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_12_3@example.com/"><script type="text/javascript">timeAgo(1547686800000);</script></a>. Noteworthy: <a href="https://lore.kernel.org/lkml/regzbot-testing-test_2_9@example.com/">[1]</a>, [<a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_12_3@example.com/">patch (SOB)</a>].</div></summary><div>[1]: <i><a href="https://lore.kernel.org/lkml/regzbot-testing-test_2_9@example.com/">test_2_9: refer to this regression on another mainling list [implicit due to Link/Closes tag]</a></i><div style="padding-left: 3em;"><script type="text/javascript">timeAgo(1547168400000);</script>, by Regzbot testingmail (monitored)</div></div>Latest patch: <a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_12_3@example.com/">test_2_12_3: add a mail with a simple patch</a><div style="padding-left: 3em;"><script type="text/javascript">timeAgo(1547686800000);</script>, by Regzbot testingmail; signed-off-by present</div>Earlier patches: <a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_12_2@example.com/">1</a>, <a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_12_1@example.com/">2</a><p>Latest five known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_12_3@example.com/">test_2_12_3: add a mail with a simple patch</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547686800000);</script>, by Regzbot testingmail; contains a signed-off patch</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_12_2@example.com/">[PATCH v2] test_2_12_2: add a mail with a simple patch</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547600400000);</script>, by Regzbot testingmail; contains a proper patch</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_12_1@example.com/">test_2_12_1: add a mail with a simple patch</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547514000000);</script>, by Regzbot testingmail; contains a simple patch</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/lkml/regzbot-testing-test_2_9@example.com/">test_2_9: refer to this regression on another mainling list</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547168400000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_7@example.com/">test_2_7: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546995600000);</script>, by Regzbot testingmail</div></li></ul></p><p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/lkml/regzbot-testing-test_2_9@example.com/">relate: https://lore.kernel.org/lkml/regzbot-testing-test_2_9@example.com/ test_2_9: refer to this regression on another mainling list [implicit due to Link/Closes tag]</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547168400000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_7@example.com/">unrelate: https://lore.kernel.org/lkml/regzbot-testing-test_2_3@example.com</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546995600000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/lkml/regzbot-testing-test_2_6@example.com/">summary: new title set via a monitored thread</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546909200000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_4@example.com/">relate: https://lore.kernel.org/lkml/regzbot-testing-test_2_3@example.com</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546736400000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/lkml/regzbot-testing-test_2_3@example.com/">note: https://lore.kernel.org/regressions/regzbot-testing-test_2_0@example.com test_2_3: refer to this regression on another mainling list [implicit due to link]</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546650000000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_2@example.com/">unrelate: https://www.kernel.org/releases.html</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546563600000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_1@example.com/">relatebrief: https://www.kernel.org/releases.html Updated linktitle</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546477200000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_0_1@example.com/">relatebrief: https://www.kernel.org/releases.html Linktitle</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546390800000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_0@example.com/">introduced: v1.8..v1.9-rc1</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546304400000);</script>, by Regzbot testingmail</div></li></ul></p><p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li></li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_2_0@example.com/">https://lore.kernel.org/r/regzbot-testing-test_2_0@example.com/</a></li></ul></p></details>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>all others with unknown culprit and activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>on back burner with activity in the past six months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+  </table>
+  <hr>
+  <p style="text-align: center">[compiled by <a href="https://linux-regtracking.leemhuis.info">regzbot</a> on 2019-01-31 01:00:00 (UTC). Wanna know more about regzbot? Then check out its <a href="https://gitlab.com/knurd42/regzbot/-/blob/main/docs/getting_started.md">getting started guide</a> or its <a href="https://gitlab.com/knurd42/regzbot/-/blob/main/docs/reference.md">reference documentation</a>.]</p>
+</body>
+-----END WEB offltest_2_12-----
+
+-----BEGIN WEB offltest_2_13-----
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+</head>
+<body>
+  <script src="../relativetime.js" type="text/javascript"></script>
+  <h1>Linux kernel regression status</h1>
+  <h2><a href="../next/">[next]</a>&nbsp;[mainline]&nbsp;<a href="../stable/">[stable/longterm]</a>&nbsp;•&nbsp;<a href="../new/">[new]</a>&nbsp;•&nbsp;<a href="../all/">[all]</a>&nbsp;•&nbsp;<a href="../resolved/">[resolved]</a>&nbsp;<a href="../inconclusive/">[inconclusive]</a>&nbsp;</h2>
+  <table style="width:100%;">
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>current cycle (v1.10.. aka v1.11-rc), culprit identified</strong>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>
+            <a href="https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?h=master&amp;id=23bde5c338c7d028609c1af64173853fb1b84018">23bde5c338c7</a>
+          </li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;"><summary style="list-style-position: outside;"><strong><i>new title set via a monitored thread</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_0@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_2_0@example.com/">activity</a>: <a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_0@example.com/"><script type="text/javascript">timeAgo(1546304400000);</script></a> &amp; <a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_13_0@example.com/"><script type="text/javascript">timeAgo(1547773200000);</script></a>. Noteworthy: <a href="https://lore.kernel.org/lkml/regzbot-testing-test_2_9@example.com/">[1]</a>, [<a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_12_3@example.com/">patch (SOB)</a>].</div></summary><div>[1]: <i><a href="https://lore.kernel.org/lkml/regzbot-testing-test_2_9@example.com/">test_2_9: refer to this regression on another mainling list [implicit due to Link/Closes tag]</a></i><div style="padding-left: 3em;"><script type="text/javascript">timeAgo(1547168400000);</script>, by Regzbot testingmail (monitored)</div></div>Latest patch: <a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_12_3@example.com/">test_2_12_3: add a mail with a simple patch</a><div style="padding-left: 3em;"><script type="text/javascript">timeAgo(1547686800000);</script>, by Regzbot testingmail; signed-off-by present</div>Earlier patches: <a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_12_2@example.com/">1</a>, <a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_12_1@example.com/">2</a><p>Latest five known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_13_0@example.com/">test_2_13_0: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547773200000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_12_3@example.com/">test_2_12_3: add a mail with a simple patch</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547686800000);</script>, by Regzbot testingmail; contains a signed-off patch</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_12_2@example.com/">[PATCH v2] test_2_12_2: add a mail with a simple patch</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547600400000);</script>, by Regzbot testingmail; contains a proper patch</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_12_1@example.com/">test_2_12_1: add a mail with a simple patch</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547514000000);</script>, by Regzbot testingmail; contains a simple patch</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/lkml/regzbot-testing-test_2_9@example.com/">test_2_9: refer to this regression on another mainling list</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547168400000);</script>, by Regzbot testingmail</div></li></ul></p><p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_13_1@example.com/">note: "test_2_13_1: Lorem ipsum dolor sit amet" contains a 'Fixes:' tag for the culprit of this regression</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547859600000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_13_0@example.com/">introduced: 23bde5c338c7d028609c1af64173853fb1b84018</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547773200000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/lkml/regzbot-testing-test_2_9@example.com/">relate: https://lore.kernel.org/lkml/regzbot-testing-test_2_9@example.com/ test_2_9: refer to this regression on another mainling list [implicit due to Link/Closes tag]</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547168400000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_7@example.com/">unrelate: https://lore.kernel.org/lkml/regzbot-testing-test_2_3@example.com</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546995600000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/lkml/regzbot-testing-test_2_6@example.com/">summary: new title set via a monitored thread</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546909200000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_4@example.com/">relate: https://lore.kernel.org/lkml/regzbot-testing-test_2_3@example.com</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546736400000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/lkml/regzbot-testing-test_2_3@example.com/">note: https://lore.kernel.org/regressions/regzbot-testing-test_2_0@example.com test_2_3: refer to this regression on another mainling list [implicit due to link]</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546650000000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_2@example.com/">unrelate: https://www.kernel.org/releases.html</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546563600000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_1@example.com/">relatebrief: https://www.kernel.org/releases.html Updated linktitle</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546477200000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_0_1@example.com/">relatebrief: https://www.kernel.org/releases.html Linktitle</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546390800000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_0@example.com/">introduced: v1.8..v1.9-rc1</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546304400000);</script>, by Regzbot testingmail</div></li></ul></p><p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li>Fixes: 23bde5c338c7 ("This is a mainline_master commit for testing regzbot, the content doesn't matter.")</li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_2_0@example.com/">https://lore.kernel.org/r/regzbot-testing-test_2_0@example.com/</a></li></ul></p></details>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>current cycle (v1.10.. aka v1.11-rc), unknown culprit</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>previous cycle (v1.9..v1.10), culprit identified, with activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>older cycles (..v1.9), culprit identified, with activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>previous cycle (v1.9..v1.10), unknown culprit, with activity in the past three weeks</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>older cycles (..v1.9), unknown culprit, with activity in the past three weeks</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>all others with unknown culprit and activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>on back burner with activity in the past six months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+  </table>
+  <hr>
+  <p style="text-align: center">[compiled by <a href="https://linux-regtracking.leemhuis.info">regzbot</a> on 2019-01-31 01:00:00 (UTC). Wanna know more about regzbot? Then check out its <a href="https://gitlab.com/knurd42/regzbot/-/blob/main/docs/getting_started.md">getting started guide</a> or its <a href="https://gitlab.com/knurd42/regzbot/-/blob/main/docs/reference.md">reference documentation</a>.]</p>
+</body>
+-----END WEB offltest_2_13-----
+
+-----BEGIN WEB offltest_2_14-----
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+</head>
+<body>
+  <script src="../relativetime.js" type="text/javascript"></script>
+  <h1>Linux kernel regression status</h1>
+  <h2><a href="../next/">[next]</a>&nbsp;[mainline]&nbsp;<a href="../stable/">[stable/longterm]</a>&nbsp;•&nbsp;<a href="../new/">[new]</a>&nbsp;•&nbsp;<a href="../all/">[all]</a>&nbsp;•&nbsp;<a href="../resolved/">[resolved]</a>&nbsp;<a href="../inconclusive/">[inconclusive]</a>&nbsp;</h2>
+  <table style="width:100%;">
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>current cycle (v1.10.. aka v1.11-rc), culprit identified</strong>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>
+            <a href="https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?h=master&amp;id=23bde5c338c7d028609c1af64173853fb1b84018">23bde5c338c7</a>
+          </li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;"><summary style="list-style-position: outside;"><strong><i>new title set via a monitored thread</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_0@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_2_0@example.com/">activity</a>: <a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_0@example.com/"><script type="text/javascript">timeAgo(1546304400000);</script></a> &amp; <a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_13_0@example.com/"><script type="text/javascript">timeAgo(1547773200000);</script></a>. Noteworthy: <a href="https://lore.kernel.org/lkml/regzbot-testing-test_2_9@example.com/">[1]</a>, [<a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_12_3@example.com/">patch (SOB)</a>].</div></summary><div>[1]: <i><a href="https://lore.kernel.org/lkml/regzbot-testing-test_2_9@example.com/">test_2_9: refer to this regression on another mainling list [implicit due to Link/Closes tag]</a></i><div style="padding-left: 3em;"><script type="text/javascript">timeAgo(1547168400000);</script>, by Regzbot testingmail (monitored)</div></div>Latest patch: <a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_12_3@example.com/">test_2_12_3: add a mail with a simple patch</a><div style="padding-left: 3em;"><script type="text/javascript">timeAgo(1547686800000);</script>, by Regzbot testingmail; signed-off-by present</div>Earlier patches: <a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_12_2@example.com/">1</a>, <a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_12_1@example.com/">2</a><p>Latest five known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_13_0@example.com/">test_2_13_0: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547773200000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_12_3@example.com/">test_2_12_3: add a mail with a simple patch</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547686800000);</script>, by Regzbot testingmail; contains a signed-off patch</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_12_2@example.com/">[PATCH v2] test_2_12_2: add a mail with a simple patch</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547600400000);</script>, by Regzbot testingmail; contains a proper patch</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_12_1@example.com/">test_2_12_1: add a mail with a simple patch</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547514000000);</script>, by Regzbot testingmail; contains a simple patch</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/lkml/regzbot-testing-test_2_9@example.com/">test_2_9: refer to this regression on another mainling list</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547168400000);</script>, by Regzbot testingmail</div></li></ul></p><p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_13_1@example.com/">note: "test_2_13_1: Lorem ipsum dolor sit amet" contains a 'Fixes:' tag for the culprit of this regression</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547859600000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_13_0@example.com/">introduced: 23bde5c338c7d028609c1af64173853fb1b84018</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547773200000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/lkml/regzbot-testing-test_2_9@example.com/">relate: https://lore.kernel.org/lkml/regzbot-testing-test_2_9@example.com/ test_2_9: refer to this regression on another mainling list [implicit due to Link/Closes tag]</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547168400000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_7@example.com/">unrelate: https://lore.kernel.org/lkml/regzbot-testing-test_2_3@example.com</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546995600000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/lkml/regzbot-testing-test_2_6@example.com/">summary: new title set via a monitored thread</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546909200000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_4@example.com/">relate: https://lore.kernel.org/lkml/regzbot-testing-test_2_3@example.com</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546736400000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/lkml/regzbot-testing-test_2_3@example.com/">note: https://lore.kernel.org/regressions/regzbot-testing-test_2_0@example.com test_2_3: refer to this regression on another mainling list [implicit due to link]</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546650000000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_2@example.com/">unrelate: https://www.kernel.org/releases.html</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546563600000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_1@example.com/">relatebrief: https://www.kernel.org/releases.html Updated linktitle</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546477200000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_0_1@example.com/">relatebrief: https://www.kernel.org/releases.html Linktitle</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546390800000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_0@example.com/">introduced: v1.8..v1.9-rc1</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546304400000);</script>, by Regzbot testingmail</div></li></ul></p><p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li>Fixes: 23bde5c338c7 ("This is a mainline_master commit for testing regzbot, the content doesn't matter.")</li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_2_0@example.com/">https://lore.kernel.org/r/regzbot-testing-test_2_0@example.com/</a></li></ul></p></details>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>current cycle (v1.10.. aka v1.11-rc), unknown culprit</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>previous cycle (v1.9..v1.10), culprit identified, with activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>older cycles (..v1.9), culprit identified, with activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>previous cycle (v1.9..v1.10), unknown culprit, with activity in the past three weeks</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>older cycles (..v1.9), unknown culprit, with activity in the past three weeks</strong>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.8..v1.9-rc1</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_2_14_0: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_14_0@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_2_14_0@example.com/">activity</a>: <a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_14_0@example.com/"><script type="text/javascript">timeAgo(1547946000000);</script></a> &amp; <a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_14_2@example.com/"><script type="text/javascript">timeAgo(1548118800000);</script></a>. Noteworthy: <a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_14_2@example.com/">[1]</a>.</div></summary>
+          <div>[1]: <i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_14_2@example.com/">test_2_14_2: refer to this regression on another mainling list [implicit due to Link/Closes tag]</a></i><div style="padding-left: 3em;"><script type="text/javascript">timeAgo(1548118800000);</script>, by Regzbot testingmail (monitored)</div></div>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_14_2@example.com/">test_2_14_2: refer to this regression on another mainling list</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1548118800000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_14_0@example.com/">test_2_14_0: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547946000000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_14_2@example.com/">relate: https://lore.kernel.org/regressions/regzbot-testing-test_2_14_2@example.com/ test_2_14_2: refer to this regression on another mainling list [implicit due to Link/Closes tag]</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1548118800000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_14_0@example.com/">introduced: v1.8..v1.9-rc1</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547946000000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li></li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_2_14_0@example.com/">https://lore.kernel.org/r/regzbot-testing-test_2_14_0@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.8..v1.9-rc1</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_2_14_1: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_14_1@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_2_14_1@example.com/">activity</a>: <a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_14_1@example.com/"><script type="text/javascript">timeAgo(1548032400000);</script></a> &amp; <a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_14_2@example.com/"><script type="text/javascript">timeAgo(1548118800000);</script></a>. Noteworthy: <a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_14_2@example.com/">[1]</a>.</div></summary>
+          <div>[1]: <i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_14_2@example.com/">test_2_14_2: refer to this regression on another mainling list [implicit due to Link/Closes tag]</a></i><div style="padding-left: 3em;"><script type="text/javascript">timeAgo(1548118800000);</script>, by Regzbot testingmail (monitored)</div></div>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_14_2@example.com/">test_2_14_2: refer to this regression on another mainling list</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1548118800000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_14_1@example.com/">test_2_14_1: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1548032400000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_14_2@example.com/">relate: https://lore.kernel.org/regressions/regzbot-testing-test_2_14_2@example.com/ test_2_14_2: refer to this regression on another mainling list [implicit due to Link/Closes tag]</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1548118800000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_14_1@example.com/">introduced: v1.8..v1.9-rc1</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1548032400000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li></li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_2_14_1@example.com/">https://lore.kernel.org/r/regzbot-testing-test_2_14_1@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>all others with unknown culprit and activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>on back burner with activity in the past six months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+  </table>
+  <hr>
+  <p style="text-align: center">[compiled by <a href="https://linux-regtracking.leemhuis.info">regzbot</a> on 2019-01-31 01:00:00 (UTC). Wanna know more about regzbot? Then check out its <a href="https://gitlab.com/knurd42/regzbot/-/blob/main/docs/getting_started.md">getting started guide</a> or its <a href="https://gitlab.com/knurd42/regzbot/-/blob/main/docs/reference.md">reference documentation</a>.]</p>
+</body>
+-----END WEB offltest_2_14-----
+
+-----BEGIN WEB offltest_2_15-----
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+</head>
+<body>
+  <script src="../relativetime.js" type="text/javascript"></script>
+  <h1>Linux kernel regression status</h1>
+  <h2><a href="../next/">[next]</a>&nbsp;[mainline]&nbsp;<a href="../stable/">[stable/longterm]</a>&nbsp;•&nbsp;<a href="../new/">[new]</a>&nbsp;•&nbsp;<a href="../all/">[all]</a>&nbsp;•&nbsp;<a href="../resolved/">[resolved]</a>&nbsp;<a href="../inconclusive/">[inconclusive]</a>&nbsp;</h2>
+  <table style="width:100%;">
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>current cycle (v1.10.. aka v1.11-rc), culprit identified</strong>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>
+            <a href="https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?h=master&amp;id=23bde5c338c7d028609c1af64173853fb1b84018">23bde5c338c7</a>
+          </li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;"><summary style="list-style-position: outside;"><strong><i>new title set via a monitored thread</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_0@example.com/">Regzbot testingmail</a> and <a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_14_0@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_2_14_0@example.com/">activity</a>: <a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_0@example.com/"><script type="text/javascript">timeAgo(1546304400000);</script></a> &amp; <a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_15_0@example.com/"><script type="text/javascript">timeAgo(1548205200000);</script></a>. Noteworthy: <a href="https://lore.kernel.org/lkml/regzbot-testing-test_2_9@example.com/">[1]</a>, <a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_14_2@example.com/">[2]</a>, [<a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_12_3@example.com/">patch (SOB)</a>].</div></summary><div>[1]: <i><a href="https://lore.kernel.org/lkml/regzbot-testing-test_2_9@example.com/">test_2_9: refer to this regression on another mainling list [implicit due to Link/Closes tag]</a></i><div style="padding-left: 3em;"><script type="text/javascript">timeAgo(1547168400000);</script>, by Regzbot testingmail (monitored)</div></div><div>[2]: <i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_14_2@example.com/">test_2_14_2: refer to this regression on another mainling list [implicit due to Link/Closes tag]</a></i><div style="padding-left: 3em;"><script type="text/javascript">timeAgo(1548118800000);</script>, by Regzbot testingmail (monitored) [<a href="../regression/regzbot-testing-test_2_14_0@example.com/">via dup</a>]</div></div>Latest patch: <a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_12_3@example.com/">test_2_12_3: add a mail with a simple patch</a><div style="padding-left: 3em;"><script type="text/javascript">timeAgo(1547686800000);</script>, by Regzbot testingmail; signed-off-by present</div>Earlier patches: <a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_12_2@example.com/">1</a>, <a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_12_1@example.com/">2</a><p>Latest five known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_15_0@example.com/">test_2_15_0: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1548205200000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_14_2@example.com/">test_2_14_2: refer to this regression on another mainling list</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1548118800000);</script>, by Regzbot testingmail [<a href="../regression/lore/regzbot-testing-test_2_14_0@example.com/">via dup</a>]</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_14_0@example.com/">test_2_14_0: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547946000000);</script>, by Regzbot testingmail [<a href="../regression/lore/regzbot-testing-test_2_14_0@example.com/">via dup</a>]</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_13_0@example.com/">test_2_13_0: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547773200000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_12_3@example.com/">test_2_12_3: add a mail with a simple patch</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547686800000);</script>, by Regzbot testingmail; contains a signed-off patch</div></li></ul></p><p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_15_0@example.com/">duplicate: https://lore.kernel.org/regressions/regzbot-testing-test_2_14_0@example.com</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1548205200000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_13_1@example.com/">note: "test_2_13_1: Lorem ipsum dolor sit amet" contains a 'Fixes:' tag for the culprit of this regression</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547859600000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_13_0@example.com/">introduced: 23bde5c338c7d028609c1af64173853fb1b84018</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547773200000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/lkml/regzbot-testing-test_2_9@example.com/">relate: https://lore.kernel.org/lkml/regzbot-testing-test_2_9@example.com/ test_2_9: refer to this regression on another mainling list [implicit due to Link/Closes tag]</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547168400000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_7@example.com/">unrelate: https://lore.kernel.org/lkml/regzbot-testing-test_2_3@example.com</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546995600000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/lkml/regzbot-testing-test_2_6@example.com/">summary: new title set via a monitored thread</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546909200000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_4@example.com/">relate: https://lore.kernel.org/lkml/regzbot-testing-test_2_3@example.com</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546736400000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/lkml/regzbot-testing-test_2_3@example.com/">note: https://lore.kernel.org/regressions/regzbot-testing-test_2_0@example.com test_2_3: refer to this regression on another mainling list [implicit due to link]</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546650000000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_2@example.com/">unrelate: https://www.kernel.org/releases.html</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546563600000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_1@example.com/">relatebrief: https://www.kernel.org/releases.html Updated linktitle</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546477200000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_0_1@example.com/">relatebrief: https://www.kernel.org/releases.html Linktitle</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546390800000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_0@example.com/">introduced: v1.8..v1.9-rc1</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546304400000);</script>, by Regzbot testingmail</div></li></ul></p><p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li>Fixes: 23bde5c338c7 ("This is a mainline_master commit for testing regzbot, the content doesn't matter.")</li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_2_0@example.com/">https://lore.kernel.org/r/regzbot-testing-test_2_0@example.com/</a></li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_2_14_0@example.com/">https://lore.kernel.org/r/regzbot-testing-test_2_14_0@example.com/</a></li></ul></p></details>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>current cycle (v1.10.. aka v1.11-rc), unknown culprit</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>previous cycle (v1.9..v1.10), culprit identified, with activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>older cycles (..v1.9), culprit identified, with activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>previous cycle (v1.9..v1.10), unknown culprit, with activity in the past three weeks</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>older cycles (..v1.9), unknown culprit, with activity in the past three weeks</strong>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.8..v1.9-rc1</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_2_14_1: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_14_1@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_2_14_1@example.com/">activity</a>: <a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_14_1@example.com/"><script type="text/javascript">timeAgo(1548032400000);</script></a> &amp; <a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_14_2@example.com/"><script type="text/javascript">timeAgo(1548118800000);</script></a>. Noteworthy: <a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_14_2@example.com/">[1]</a>.</div></summary>
+          <div>[1]: <i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_14_2@example.com/">test_2_14_2: refer to this regression on another mainling list [implicit due to Link/Closes tag]</a></i><div style="padding-left: 3em;"><script type="text/javascript">timeAgo(1548118800000);</script>, by Regzbot testingmail (monitored)</div></div>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_14_2@example.com/">test_2_14_2: refer to this regression on another mainling list</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1548118800000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_14_1@example.com/">test_2_14_1: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1548032400000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_14_2@example.com/">relate: https://lore.kernel.org/regressions/regzbot-testing-test_2_14_2@example.com/ test_2_14_2: refer to this regression on another mainling list [implicit due to Link/Closes tag]</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1548118800000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_14_1@example.com/">introduced: v1.8..v1.9-rc1</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1548032400000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li></li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_2_14_1@example.com/">https://lore.kernel.org/r/regzbot-testing-test_2_14_1@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>all others with unknown culprit and activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>on back burner with activity in the past six months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+  </table>
+  <hr>
+  <p style="text-align: center">[compiled by <a href="https://linux-regtracking.leemhuis.info">regzbot</a> on 2019-01-31 01:00:00 (UTC). Wanna know more about regzbot? Then check out its <a href="https://gitlab.com/knurd42/regzbot/-/blob/main/docs/getting_started.md">getting started guide</a> or its <a href="https://gitlab.com/knurd42/regzbot/-/blob/main/docs/reference.md">reference documentation</a>.]</p>
+</body>
+-----END WEB offltest_2_15-----
+
+-----BEGIN WEB offltest_2_16-----
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+</head>
+<body>
+  <script src="../relativetime.js" type="text/javascript"></script>
+  <h1>Linux kernel regression status</h1>
+  <h2><a href="../next/">[next]</a>&nbsp;[mainline]&nbsp;<a href="../stable/">[stable/longterm]</a>&nbsp;•&nbsp;<a href="../new/">[new]</a>&nbsp;•&nbsp;<a href="../all/">[all]</a>&nbsp;•&nbsp;<a href="../resolved/">[resolved]</a>&nbsp;<a href="../inconclusive/">[inconclusive]</a>&nbsp;</h2>
+  <table style="width:100%;">
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>current cycle (v1.10.. aka v1.11-rc), culprit identified</strong>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>
+            <a href="https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?h=master&amp;id=23bde5c338c7d028609c1af64173853fb1b84018">23bde5c338c7</a>
+          </li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;"><summary style="list-style-position: outside;"><strong><i>new title set via a monitored thread</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_0@example.com/">Regzbot testingmail</a> and <a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_14_0@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_2_14_0@example.com/">activity</a>: <a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_0@example.com/"><script type="text/javascript">timeAgo(1546304400000);</script></a> &amp; <a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_15_0@example.com/"><script type="text/javascript">timeAgo(1548205200000);</script></a>. Noteworthy: <a href="https://lore.kernel.org/lkml/regzbot-testing-test_2_9@example.com/">[1]</a>, <a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_14_2@example.com/">[2]</a>, [<a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_12_3@example.com/">patch (SOB)</a>].</div></summary><div>[1]: <i><a href="https://lore.kernel.org/lkml/regzbot-testing-test_2_9@example.com/">test_2_9: refer to this regression on another mainling list [implicit due to Link/Closes tag]</a></i><div style="padding-left: 3em;"><script type="text/javascript">timeAgo(1547168400000);</script>, by Regzbot testingmail (monitored)</div></div><div>[2]: <i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_14_2@example.com/">test_2_14_2: refer to this regression on another mainling list [implicit due to Link/Closes tag]</a></i><div style="padding-left: 3em;"><script type="text/javascript">timeAgo(1548118800000);</script>, by Regzbot testingmail (monitored) [<a href="../regression/regzbot-testing-test_2_14_0@example.com/">via dup</a>]</div></div>Latest patch: <a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_12_3@example.com/">test_2_12_3: add a mail with a simple patch</a><div style="padding-left: 3em;"><script type="text/javascript">timeAgo(1547686800000);</script>, by Regzbot testingmail; signed-off-by present</div>Earlier patches: <a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_12_2@example.com/">1</a>, <a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_12_1@example.com/">2</a><p>Latest five known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_15_0@example.com/">test_2_15_0: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1548205200000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_14_2@example.com/">test_2_14_2: refer to this regression on another mainling list</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1548118800000);</script>, by Regzbot testingmail [<a href="../regression/lore/regzbot-testing-test_2_14_0@example.com/">via dup</a>]</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_14_0@example.com/">test_2_14_0: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547946000000);</script>, by Regzbot testingmail [<a href="../regression/lore/regzbot-testing-test_2_14_0@example.com/">via dup</a>]</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_13_0@example.com/">test_2_13_0: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547773200000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_12_3@example.com/">test_2_12_3: add a mail with a simple patch</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547686800000);</script>, by Regzbot testingmail; contains a signed-off patch</div></li></ul></p><p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_15_0@example.com/">duplicate: https://lore.kernel.org/regressions/regzbot-testing-test_2_14_0@example.com</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1548205200000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_13_1@example.com/">note: "test_2_13_1: Lorem ipsum dolor sit amet" contains a 'Fixes:' tag for the culprit of this regression</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547859600000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_13_0@example.com/">introduced: 23bde5c338c7d028609c1af64173853fb1b84018</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547773200000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/lkml/regzbot-testing-test_2_9@example.com/">relate: https://lore.kernel.org/lkml/regzbot-testing-test_2_9@example.com/ test_2_9: refer to this regression on another mainling list [implicit due to Link/Closes tag]</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547168400000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_7@example.com/">unrelate: https://lore.kernel.org/lkml/regzbot-testing-test_2_3@example.com</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546995600000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/lkml/regzbot-testing-test_2_6@example.com/">summary: new title set via a monitored thread</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546909200000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_4@example.com/">relate: https://lore.kernel.org/lkml/regzbot-testing-test_2_3@example.com</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546736400000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/lkml/regzbot-testing-test_2_3@example.com/">note: https://lore.kernel.org/regressions/regzbot-testing-test_2_0@example.com test_2_3: refer to this regression on another mainling list [implicit due to link]</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546650000000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_2@example.com/">unrelate: https://www.kernel.org/releases.html</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546563600000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_1@example.com/">relatebrief: https://www.kernel.org/releases.html Updated linktitle</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546477200000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_0_1@example.com/">relatebrief: https://www.kernel.org/releases.html Linktitle</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546390800000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_0@example.com/">introduced: v1.8..v1.9-rc1</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546304400000);</script>, by Regzbot testingmail</div></li></ul></p><p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li>Fixes: 23bde5c338c7 ("This is a mainline_master commit for testing regzbot, the content doesn't matter.")</li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_2_0@example.com/">https://lore.kernel.org/r/regzbot-testing-test_2_0@example.com/</a></li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_2_14_0@example.com/">https://lore.kernel.org/r/regzbot-testing-test_2_14_0@example.com/</a></li></ul></p></details>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>current cycle (v1.10.. aka v1.11-rc), unknown culprit</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>previous cycle (v1.9..v1.10), culprit identified, with activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>older cycles (..v1.9), culprit identified, with activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>previous cycle (v1.9..v1.10), unknown culprit, with activity in the past three weeks</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>older cycles (..v1.9), unknown culprit, with activity in the past three weeks</strong>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.8..v1.9-rc1</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_2_16_0: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_16_0@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_2_16_0@example.com/">activity</a>: <a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_16_0@example.com/"><script type="text/javascript">timeAgo(1548291600000);</script></a> &amp; <a href="https://lore.kernel.org/lkml/regzbot-testing-test_2_16@example.com/"><script type="text/javascript">timeAgo(1548378000000);</script></a>. Noteworthy: <a href="https://lore.kernel.org/lkml/regzbot-testing-test_2_16@example.com/">[1]</a>.</div></summary>
+          <div>[1]: <i><a href="https://lore.kernel.org/lkml/regzbot-testing-test_2_16@example.com/">test_2_16: refer to newly created regression on another mainling list [implicit due to Link/Closes tag]</a></i><div style="padding-left: 3em;"><script type="text/javascript">timeAgo(1548378000000);</script>, by Regzbot testingmail (monitored)</div></div>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/lkml/regzbot-testing-test_2_16@example.com/">test_2_16: refer to newly created regression on another mainling list</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1548378000000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_16_0@example.com/">test_2_16_0: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1548291600000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/lkml/regzbot-testing-test_2_16@example.com/">relate: https://lore.kernel.org/lkml/regzbot-testing-test_2_16@example.com/ test_2_16: refer to newly created regression on another mainling list [implicit due to Link/Closes tag]</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1548378000000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_16_0@example.com/">introduced: v1.8..v1.9-rc1</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1548291600000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li></li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_2_16_0@example.com/">https://lore.kernel.org/r/regzbot-testing-test_2_16_0@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.8..v1.9-rc1</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_2_14_1: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_14_1@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_2_14_1@example.com/">activity</a>: <a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_14_1@example.com/"><script type="text/javascript">timeAgo(1548032400000);</script></a> &amp; <a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_14_2@example.com/"><script type="text/javascript">timeAgo(1548118800000);</script></a>. Noteworthy: <a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_14_2@example.com/">[1]</a>.</div></summary>
+          <div>[1]: <i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_14_2@example.com/">test_2_14_2: refer to this regression on another mainling list [implicit due to Link/Closes tag]</a></i><div style="padding-left: 3em;"><script type="text/javascript">timeAgo(1548118800000);</script>, by Regzbot testingmail (monitored)</div></div>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_14_2@example.com/">test_2_14_2: refer to this regression on another mainling list</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1548118800000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_14_1@example.com/">test_2_14_1: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1548032400000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_14_2@example.com/">relate: https://lore.kernel.org/regressions/regzbot-testing-test_2_14_2@example.com/ test_2_14_2: refer to this regression on another mainling list [implicit due to Link/Closes tag]</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1548118800000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_2_14_1@example.com/">introduced: v1.8..v1.9-rc1</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1548032400000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li></li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_2_14_1@example.com/">https://lore.kernel.org/r/regzbot-testing-test_2_14_1@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>all others with unknown culprit and activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>on back burner with activity in the past six months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+  </table>
+  <hr>
+  <p style="text-align: center">[compiled by <a href="https://linux-regtracking.leemhuis.info">regzbot</a> on 2019-01-31 01:00:00 (UTC). Wanna know more about regzbot? Then check out its <a href="https://gitlab.com/knurd42/regzbot/-/blob/main/docs/getting_started.md">getting started guide</a> or its <a href="https://gitlab.com/knurd42/regzbot/-/blob/main/docs/reference.md">reference documentation</a>.]</p>
+</body>
+-----END WEB offltest_2_16-----
+
+-----BEGIN WEB offltest_3_0-----
+-----END WEB offltest_3_0-----
+
+-----BEGIN WEB offltest_3_1-----
+-----END WEB offltest_3_1-----
+
+-----BEGIN WEB offltest_3_2-----
+-----END WEB offltest_3_2-----
+
+-----BEGIN WEB offltest_3_3-----
+-----END WEB offltest_3_3-----
+
+-----BEGIN WEB offltest_3_4-----
+-----END WEB offltest_3_4-----
+
+-----BEGIN WEB offltest_3_5-----
+-----END WEB offltest_3_5-----
+
+-----BEGIN WEB offltest_4_0-----
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+</head>
+<body>
+  <script src="../relativetime.js" type="text/javascript"></script>
+  <h1>Linux kernel regression status</h1>
+  <h2><a href="../next/">[next]</a>&nbsp;[mainline]&nbsp;<a href="../stable/">[stable/longterm]</a>&nbsp;•&nbsp;<a href="../new/">[new]</a>&nbsp;•&nbsp;<a href="../all/">[all]</a>&nbsp;•&nbsp;<a href="../resolved/">[resolved]</a>&nbsp;<a href="../inconclusive/">[inconclusive]</a>&nbsp;</h2>
+  <table style="width:100%;">
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>current cycle (v1.10.. aka v1.11-rc), culprit identified</strong>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>
+            <a href="https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?h=master&amp;id=23bde5c338c7d028609c1af64173853fb1b84018">23bde5c338c7</a>
+          </li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_4_0_1: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_0_1@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_4_0_1@example.com/">activity</a>: <script type="text/javascript">timeAgo(1546390800000);</script>.</div></summary>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_0_1@example.com/">test_4_0_1: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546390800000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_0_1@example.com/">introduced: 23bde5c338c7d028609c1af64173853fb1b84018</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546390800000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li>Fixes: 23bde5c338c7 ("This is a mainline_master commit for testing regzbot, the content doesn't matter.")</li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_4_0_1@example.com/">https://lore.kernel.org/r/regzbot-testing-test_4_0_1@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>current cycle (v1.10.. aka v1.11-rc), unknown culprit</strong>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.10..v1.11-rc1</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_4_0_0: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_0_0@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_4_0_0@example.com/">activity</a>: <script type="text/javascript">timeAgo(1546304400000);</script>.</div></summary>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_0_0@example.com/">test_4_0_0: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546304400000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_0_0@example.com/">introduced: v1.10..v1.11-rc1</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546304400000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li></li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_4_0_0@example.com/">https://lore.kernel.org/r/regzbot-testing-test_4_0_0@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>previous cycle (v1.9..v1.10), culprit identified, with activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>
+            <a href="https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?h=master&amp;id=bff114a4835d9abd95a627c8e4d7613cc6be163b">bff114a4835d</a>
+            <div>(v1.10^0)</div>
+          </li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_4_0_3: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_0_3@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_4_0_3@example.com/">activity</a>: <script type="text/javascript">timeAgo(1546563600000);</script>.</div></summary>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_0_3@example.com/">test_4_0_3: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546563600000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_0_3@example.com/">introduced: bff114a4835d9abd95a627c8e4d7613cc6be163b</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546563600000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li>Fixes: bff114a4835d ("This is a mainline_master commit for testing regzbot, the content doesn't matter.")</li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_4_0_3@example.com/">https://lore.kernel.org/r/regzbot-testing-test_4_0_3@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>older cycles (..v1.9), culprit identified, with activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>
+            <a href="https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?h=master&amp;id=2c5fa4b5edeb0693443b2f93a80980052eef7b58">2c5fa4b5edeb</a>
+            <div>(v1.9-rc2^0)</div>
+          </li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_4_0_5: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_0_5@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_4_0_5@example.com/">activity</a>: <script type="text/javascript">timeAgo(1546736400000);</script>.</div></summary>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_0_5@example.com/">test_4_0_5: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546736400000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_0_5@example.com/">introduced: 2c5fa4b5edeb0693443b2f93a80980052eef7b58</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546736400000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li>Fixes: 2c5fa4b5edeb ("This is a mainline_master commit for testing regzbot, the content doesn't matter.")</li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_4_0_5@example.com/">https://lore.kernel.org/r/regzbot-testing-test_4_0_5@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>previous cycle (v1.9..v1.10), unknown culprit, with activity in the past three weeks</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>older cycles (..v1.9), unknown culprit, with activity in the past three weeks</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>all others with unknown culprit and activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.10..23bde5c338c7</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_4_0_7: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_0_7@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_4_0_7@example.com/">activity</a>: <script type="text/javascript">timeAgo(1546909200000);</script>.</div></summary>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_0_7@example.com/">test_4_0_7: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546909200000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_0_7@example.com/">introduced: v1.10..</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546909200000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li></li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_4_0_7@example.com/">https://lore.kernel.org/r/regzbot-testing-test_4_0_7@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.9..v1.11-rc1</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_4_0_6: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_0_6@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_4_0_6@example.com/">activity</a>: <script type="text/javascript">timeAgo(1546822800000);</script>.</div></summary>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_0_6@example.com/">test_4_0_6: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546822800000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_0_6@example.com/">introduced: v1.9..v1.11-rc1</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546822800000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li></li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_4_0_6@example.com/">https://lore.kernel.org/r/regzbot-testing-test_4_0_6@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.8..v1.9-rc1</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_4_0_4: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_0_4@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_4_0_4@example.com/">activity</a>: <script type="text/javascript">timeAgo(1546650000000);</script>.</div></summary>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_0_4@example.com/">test_4_0_4: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546650000000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_0_4@example.com/">introduced: v1.8..v1.9-rc1</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546650000000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li></li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_4_0_4@example.com/">https://lore.kernel.org/r/regzbot-testing-test_4_0_4@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.9..v1.10-rc2</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_4_0_2: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_0_2@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_4_0_2@example.com/">activity</a>: <script type="text/javascript">timeAgo(1546477200000);</script>.</div></summary>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_0_2@example.com/">test_4_0_2: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546477200000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_0_2@example.com/">introduced: v1.9..v1.10-rc2</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546477200000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li></li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_4_0_2@example.com/">https://lore.kernel.org/r/regzbot-testing-test_4_0_2@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>on back burner with activity in the past six months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+  </table>
+  <hr>
+  <p style="text-align: center">[compiled by <a href="https://linux-regtracking.leemhuis.info">regzbot</a> on 2019-01-31 01:00:00 (UTC). Wanna know more about regzbot? Then check out its <a href="https://gitlab.com/knurd42/regzbot/-/blob/main/docs/getting_started.md">getting started guide</a> or its <a href="https://gitlab.com/knurd42/regzbot/-/blob/main/docs/reference.md">reference documentation</a>.]</p>
+</body>
+-----END WEB offltest_4_0-----
+
+-----BEGIN WEB offltest_4_1-----
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+</head>
+<body>
+  <script src="../relativetime.js" type="text/javascript"></script>
+  <h1>Linux kernel regression status</h1>
+  <h2><a href="../next/">[next]</a>&nbsp;[mainline]&nbsp;<a href="../stable/">[stable/longterm]</a>&nbsp;•&nbsp;<a href="../new/">[new]</a>&nbsp;•&nbsp;<a href="../all/">[all]</a>&nbsp;•&nbsp;<a href="../resolved/">[resolved]</a>&nbsp;<a href="../inconclusive/">[inconclusive]</a>&nbsp;</h2>
+  <table style="width:100%;">
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>current cycle (v1.10.. aka v1.11-rc), culprit identified</strong>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>
+            <a href="https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?h=master&amp;id=23bde5c338c7d028609c1af64173853fb1b84018">23bde5c338c7</a>
+          </li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_4_0_1: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_0_1@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_4_0_1@example.com/">activity</a>: <script type="text/javascript">timeAgo(1546390800000);</script>.</div></summary>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_0_1@example.com/">test_4_0_1: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546390800000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_0_1@example.com/">introduced: 23bde5c338c7d028609c1af64173853fb1b84018</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546390800000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li>Fixes: 23bde5c338c7 ("This is a mainline_master commit for testing regzbot, the content doesn't matter.")</li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_4_0_1@example.com/">https://lore.kernel.org/r/regzbot-testing-test_4_0_1@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>current cycle (v1.10.. aka v1.11-rc), unknown culprit</strong>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.10..v1.11-rc1</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_4_0_0: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_0_0@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_4_0_0@example.com/">activity</a>: <script type="text/javascript">timeAgo(1546304400000);</script>.</div></summary>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_0_0@example.com/">test_4_0_0: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546304400000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_0_0@example.com/">introduced: v1.10..v1.11-rc1</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546304400000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li></li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_4_0_0@example.com/">https://lore.kernel.org/r/regzbot-testing-test_4_0_0@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>previous cycle (v1.9..v1.10), culprit identified, with activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>
+            <a href="https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?h=master&amp;id=bff114a4835d9abd95a627c8e4d7613cc6be163b">bff114a4835d</a>
+            <div>(v1.10^0)</div>
+          </li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_4_0_3: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_0_3@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_4_0_3@example.com/">activity</a>: <script type="text/javascript">timeAgo(1546563600000);</script>.</div></summary>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_0_3@example.com/">test_4_0_3: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546563600000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_0_3@example.com/">introduced: bff114a4835d9abd95a627c8e4d7613cc6be163b</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546563600000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li>Fixes: bff114a4835d ("This is a mainline_master commit for testing regzbot, the content doesn't matter.")</li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_4_0_3@example.com/">https://lore.kernel.org/r/regzbot-testing-test_4_0_3@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>older cycles (..v1.9), culprit identified, with activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>
+            <a href="https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?h=master&amp;id=2c5fa4b5edeb0693443b2f93a80980052eef7b58">2c5fa4b5edeb</a>
+            <div>(v1.9-rc2^0)</div>
+          </li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_4_0_5: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_0_5@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_4_0_5@example.com/">activity</a>: <script type="text/javascript">timeAgo(1546736400000);</script>.</div></summary>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_0_5@example.com/">test_4_0_5: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546736400000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_0_5@example.com/">introduced: 2c5fa4b5edeb0693443b2f93a80980052eef7b58</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546736400000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li>Fixes: 2c5fa4b5edeb ("This is a mainline_master commit for testing regzbot, the content doesn't matter.")</li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_4_0_5@example.com/">https://lore.kernel.org/r/regzbot-testing-test_4_0_5@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>previous cycle (v1.9..v1.10), unknown culprit, with activity in the past three weeks</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>older cycles (..v1.9), unknown culprit, with activity in the past three weeks</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>all others with unknown culprit and activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.10..23bde5c338c7</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_4_0_7: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_0_7@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_4_0_7@example.com/">activity</a>: <script type="text/javascript">timeAgo(1546909200000);</script>.</div></summary>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_0_7@example.com/">test_4_0_7: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546909200000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_0_7@example.com/">introduced: v1.10..</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546909200000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li></li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_4_0_7@example.com/">https://lore.kernel.org/r/regzbot-testing-test_4_0_7@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.9..v1.11-rc1</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_4_0_6: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_0_6@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_4_0_6@example.com/">activity</a>: <script type="text/javascript">timeAgo(1546822800000);</script>.</div></summary>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_0_6@example.com/">test_4_0_6: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546822800000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_0_6@example.com/">introduced: v1.9..v1.11-rc1</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546822800000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li></li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_4_0_6@example.com/">https://lore.kernel.org/r/regzbot-testing-test_4_0_6@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.8..v1.9-rc1</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_4_0_4: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_0_4@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_4_0_4@example.com/">activity</a>: <script type="text/javascript">timeAgo(1546650000000);</script>.</div></summary>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_0_4@example.com/">test_4_0_4: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546650000000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_0_4@example.com/">introduced: v1.8..v1.9-rc1</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546650000000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li></li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_4_0_4@example.com/">https://lore.kernel.org/r/regzbot-testing-test_4_0_4@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.9..v1.10-rc2</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_4_0_2: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_0_2@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_4_0_2@example.com/">activity</a>: <script type="text/javascript">timeAgo(1546477200000);</script>.</div></summary>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_0_2@example.com/">test_4_0_2: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546477200000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_0_2@example.com/">introduced: v1.9..v1.10-rc2</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546477200000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li></li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_4_0_2@example.com/">https://lore.kernel.org/r/regzbot-testing-test_4_0_2@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>on back burner with activity in the past six months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+  </table>
+  <hr>
+  <p style="text-align: center">[compiled by <a href="https://linux-regtracking.leemhuis.info">regzbot</a> on 2019-01-31 01:00:00 (UTC). Wanna know more about regzbot? Then check out its <a href="https://gitlab.com/knurd42/regzbot/-/blob/main/docs/getting_started.md">getting started guide</a> or its <a href="https://gitlab.com/knurd42/regzbot/-/blob/main/docs/reference.md">reference documentation</a>.]</p>
+</body>
+-----END WEB offltest_4_1-----
+
+-----BEGIN WEB offltest_4_2-----
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+</head>
+<body>
+  <script src="../relativetime.js" type="text/javascript"></script>
+  <h1>Linux kernel regression status</h1>
+  <h2><a href="../next/">[next]</a>&nbsp;[mainline]&nbsp;<a href="../stable/">[stable/longterm]</a>&nbsp;•&nbsp;<a href="../new/">[new]</a>&nbsp;•&nbsp;<a href="../all/">[all]</a>&nbsp;•&nbsp;<a href="../resolved/">[resolved]</a>&nbsp;<a href="../inconclusive/">[inconclusive]</a>&nbsp;</h2>
+  <table style="width:100%;">
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>current cycle (v1.10.. aka v1.11-rc), culprit identified</strong>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>
+            <a href="https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?h=master&amp;id=23bde5c338c7d028609c1af64173853fb1b84018">23bde5c338c7</a>
+          </li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_4_0_1: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_0_1@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_4_0_1@example.com/">activity</a>: <script type="text/javascript">timeAgo(1546390800000);</script>.</div></summary>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_0_1@example.com/">test_4_0_1: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546390800000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_0_1@example.com/">introduced: 23bde5c338c7d028609c1af64173853fb1b84018</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546390800000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li>Fixes: 23bde5c338c7 ("This is a mainline_master commit for testing regzbot, the content doesn't matter.")</li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_4_0_1@example.com/">https://lore.kernel.org/r/regzbot-testing-test_4_0_1@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>current cycle (v1.10.. aka v1.11-rc), unknown culprit</strong>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.10..v1.11-rc1</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_4_0_0: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_0_0@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_4_0_0@example.com/">activity</a>: <script type="text/javascript">timeAgo(1546304400000);</script>.</div></summary>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_0_0@example.com/">test_4_0_0: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546304400000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_0_0@example.com/">introduced: v1.10..v1.11-rc1</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546304400000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li></li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_4_0_0@example.com/">https://lore.kernel.org/r/regzbot-testing-test_4_0_0@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>previous cycle (v1.9..v1.10), culprit identified, with activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>
+            <a href="https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?h=master&amp;id=bff114a4835d9abd95a627c8e4d7613cc6be163b">bff114a4835d</a>
+            <div>(v1.10^0)</div>
+          </li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_4_0_3: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_0_3@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_4_0_3@example.com/">activity</a>: <script type="text/javascript">timeAgo(1546563600000);</script>.</div></summary>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_0_3@example.com/">test_4_0_3: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546563600000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_0_3@example.com/">introduced: bff114a4835d9abd95a627c8e4d7613cc6be163b</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546563600000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li>Fixes: bff114a4835d ("This is a mainline_master commit for testing regzbot, the content doesn't matter.")</li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_4_0_3@example.com/">https://lore.kernel.org/r/regzbot-testing-test_4_0_3@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>older cycles (..v1.9), culprit identified, with activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>
+            <a href="https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?h=master&amp;id=2c5fa4b5edeb0693443b2f93a80980052eef7b58">2c5fa4b5edeb</a>
+            <div>(v1.9-rc2^0)</div>
+          </li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_4_0_5: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_0_5@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_4_0_5@example.com/">activity</a>: <script type="text/javascript">timeAgo(1546736400000);</script>.</div></summary>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_0_5@example.com/">test_4_0_5: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546736400000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_0_5@example.com/">introduced: 2c5fa4b5edeb0693443b2f93a80980052eef7b58</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546736400000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li>Fixes: 2c5fa4b5edeb ("This is a mainline_master commit for testing regzbot, the content doesn't matter.")</li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_4_0_5@example.com/">https://lore.kernel.org/r/regzbot-testing-test_4_0_5@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>previous cycle (v1.9..v1.10), unknown culprit, with activity in the past three weeks</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>older cycles (..v1.9), unknown culprit, with activity in the past three weeks</strong>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.9.2..v1.10</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_4_2_4: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_2_4@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_4_2_4@example.com/">activity</a>: <script type="text/javascript">timeAgo(1547600400000);</script>.</div></summary>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_2_4@example.com/">test_4_2_4: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547600400000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_2_4@example.com/">introduced: v1.9.2..v1.10</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547600400000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li></li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_4_2_4@example.com/">https://lore.kernel.org/r/regzbot-testing-test_4_2_4@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.10.2..v1.11-rc1</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_4_2_3: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_2_3@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_4_2_3@example.com/">activity</a>: <script type="text/javascript">timeAgo(1547514000000);</script>.</div></summary>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_2_3@example.com/">test_4_2_3: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547514000000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_2_3@example.com/">introduced: v1.10.2..v1.11-rc1</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547514000000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li></li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_4_2_3@example.com/">https://lore.kernel.org/r/regzbot-testing-test_4_2_3@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.8..v1.8.1</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_4_2_2: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_2_2@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_4_2_2@example.com/">activity</a>: <script type="text/javascript">timeAgo(1547427600000);</script>.</div></summary>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_2_2@example.com/">test_4_2_2: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547427600000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_2_2@example.com/">introduced: v1.8..v1.8.1</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547427600000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li></li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_4_2_2@example.com/">https://lore.kernel.org/r/regzbot-testing-test_4_2_2@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>all others with unknown culprit and activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.10..23bde5c338c7</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_4_0_7: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_0_7@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_4_0_7@example.com/">activity</a>: <script type="text/javascript">timeAgo(1546909200000);</script>.</div></summary>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_0_7@example.com/">test_4_0_7: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546909200000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_0_7@example.com/">introduced: v1.10..</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546909200000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li></li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_4_0_7@example.com/">https://lore.kernel.org/r/regzbot-testing-test_4_0_7@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.9..v1.11-rc1</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_4_0_6: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_0_6@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_4_0_6@example.com/">activity</a>: <script type="text/javascript">timeAgo(1546822800000);</script>.</div></summary>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_0_6@example.com/">test_4_0_6: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546822800000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_0_6@example.com/">introduced: v1.9..v1.11-rc1</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546822800000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li></li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_4_0_6@example.com/">https://lore.kernel.org/r/regzbot-testing-test_4_0_6@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.8..v1.9-rc1</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_4_0_4: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_0_4@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_4_0_4@example.com/">activity</a>: <script type="text/javascript">timeAgo(1546650000000);</script>.</div></summary>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_0_4@example.com/">test_4_0_4: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546650000000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_0_4@example.com/">introduced: v1.8..v1.9-rc1</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546650000000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li></li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_4_0_4@example.com/">https://lore.kernel.org/r/regzbot-testing-test_4_0_4@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.9..v1.10-rc2</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_4_0_2: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_0_2@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_4_0_2@example.com/">activity</a>: <script type="text/javascript">timeAgo(1546477200000);</script>.</div></summary>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_0_2@example.com/">test_4_0_2: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546477200000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_0_2@example.com/">introduced: v1.9..v1.10-rc2</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546477200000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li></li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_4_0_2@example.com/">https://lore.kernel.org/r/regzbot-testing-test_4_0_2@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>on back burner with activity in the past six months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+  </table>
+  <hr>
+  <p style="text-align: center">[compiled by <a href="https://linux-regtracking.leemhuis.info">regzbot</a> on 2019-01-31 01:00:00 (UTC). Wanna know more about regzbot? Then check out its <a href="https://gitlab.com/knurd42/regzbot/-/blob/main/docs/getting_started.md">getting started guide</a> or its <a href="https://gitlab.com/knurd42/regzbot/-/blob/main/docs/reference.md">reference documentation</a>.]</p>
+</body>
+-----END WEB offltest_4_2-----
+
+-----BEGIN WEB offltest_4_3-----
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+</head>
+<body>
+  <script src="../relativetime.js" type="text/javascript"></script>
+  <h1>Linux kernel regression status</h1>
+  <h2><a href="../next/">[next]</a>&nbsp;[mainline]&nbsp;<a href="../stable/">[stable/longterm]</a>&nbsp;•&nbsp;<a href="../new/">[new]</a>&nbsp;•&nbsp;<a href="../all/">[all]</a>&nbsp;•&nbsp;<a href="../resolved/">[resolved]</a>&nbsp;<a href="../inconclusive/">[inconclusive]</a>&nbsp;</h2>
+  <table style="width:100%;">
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>current cycle (v1.10.. aka v1.11-rc), culprit identified</strong>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>
+            <a href="https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?h=master&amp;id=23bde5c338c7d028609c1af64173853fb1b84018">23bde5c338c7</a>
+          </li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_4_0_1: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_0_1@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_4_0_1@example.com/">activity</a>: <script type="text/javascript">timeAgo(1546390800000);</script>.</div></summary>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_0_1@example.com/">test_4_0_1: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546390800000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_0_1@example.com/">introduced: 23bde5c338c7d028609c1af64173853fb1b84018</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546390800000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li>Fixes: 23bde5c338c7 ("This is a mainline_master commit for testing regzbot, the content doesn't matter.")</li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_4_0_1@example.com/">https://lore.kernel.org/r/regzbot-testing-test_4_0_1@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>current cycle (v1.10.. aka v1.11-rc), unknown culprit</strong>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.10..v1.11-rc1</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_4_0_0: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_0_0@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_4_0_0@example.com/">activity</a>: <script type="text/javascript">timeAgo(1546304400000);</script>.</div></summary>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_0_0@example.com/">test_4_0_0: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546304400000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_0_0@example.com/">introduced: v1.10..v1.11-rc1</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546304400000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li></li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_4_0_0@example.com/">https://lore.kernel.org/r/regzbot-testing-test_4_0_0@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>previous cycle (v1.9..v1.10), culprit identified, with activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>
+            <a href="https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?h=master&amp;id=bff114a4835d9abd95a627c8e4d7613cc6be163b">bff114a4835d</a>
+            <div>(v1.10^0)</div>
+          </li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_4_0_3: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_0_3@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_4_0_3@example.com/">activity</a>: <script type="text/javascript">timeAgo(1546563600000);</script>.</div></summary>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_0_3@example.com/">test_4_0_3: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546563600000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_0_3@example.com/">introduced: bff114a4835d9abd95a627c8e4d7613cc6be163b</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546563600000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li>Fixes: bff114a4835d ("This is a mainline_master commit for testing regzbot, the content doesn't matter.")</li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_4_0_3@example.com/">https://lore.kernel.org/r/regzbot-testing-test_4_0_3@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>older cycles (..v1.9), culprit identified, with activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>
+            <a href="https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?h=master&amp;id=2c5fa4b5edeb0693443b2f93a80980052eef7b58">2c5fa4b5edeb</a>
+            <div>(v1.9-rc2^0)</div>
+          </li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_4_0_5: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_0_5@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_4_0_5@example.com/">activity</a>: <script type="text/javascript">timeAgo(1546736400000);</script>.</div></summary>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_0_5@example.com/">test_4_0_5: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546736400000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_0_5@example.com/">introduced: 2c5fa4b5edeb0693443b2f93a80980052eef7b58</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546736400000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li>Fixes: 2c5fa4b5edeb ("This is a mainline_master commit for testing regzbot, the content doesn't matter.")</li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_4_0_5@example.com/">https://lore.kernel.org/r/regzbot-testing-test_4_0_5@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>previous cycle (v1.9..v1.10), unknown culprit, with activity in the past three weeks</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>older cycles (..v1.9), unknown culprit, with activity in the past three weeks</strong>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>123456789012</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_4_3_1: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_3_1@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_4_3_1@example.com/">activity</a>: <script type="text/javascript">timeAgo(1547773200000);</script>.</div></summary>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_3_1@example.com/">test_4_3_1: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547773200000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_3_1@example.com/">introduced: 123456789012</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547773200000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li></li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_4_3_1@example.com/">https://lore.kernel.org/r/regzbot-testing-test_4_3_1@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v0.10..v0.11</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_4_3_0: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_3_0@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_4_3_0@example.com/">activity</a>: <script type="text/javascript">timeAgo(1547686800000);</script>.</div></summary>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_3_0@example.com/">test_4_3_0: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547686800000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_3_0@example.com/">introduced: v0.10..v0.11</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547686800000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li></li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_4_3_0@example.com/">https://lore.kernel.org/r/regzbot-testing-test_4_3_0@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.9.2..v1.10</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_4_2_4: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_2_4@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_4_2_4@example.com/">activity</a>: <script type="text/javascript">timeAgo(1547600400000);</script>.</div></summary>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_2_4@example.com/">test_4_2_4: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547600400000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_2_4@example.com/">introduced: v1.9.2..v1.10</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547600400000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li></li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_4_2_4@example.com/">https://lore.kernel.org/r/regzbot-testing-test_4_2_4@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.10.2..v1.11-rc1</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_4_2_3: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_2_3@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_4_2_3@example.com/">activity</a>: <script type="text/javascript">timeAgo(1547514000000);</script>.</div></summary>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_2_3@example.com/">test_4_2_3: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547514000000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_2_3@example.com/">introduced: v1.10.2..v1.11-rc1</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547514000000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li></li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_4_2_3@example.com/">https://lore.kernel.org/r/regzbot-testing-test_4_2_3@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.8..v1.8.1</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_4_2_2: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_2_2@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_4_2_2@example.com/">activity</a>: <script type="text/javascript">timeAgo(1547427600000);</script>.</div></summary>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_2_2@example.com/">test_4_2_2: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547427600000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_2_2@example.com/">introduced: v1.8..v1.8.1</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547427600000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li></li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_4_2_2@example.com/">https://lore.kernel.org/r/regzbot-testing-test_4_2_2@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>all others with unknown culprit and activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.10..23bde5c338c7</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_4_0_7: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_0_7@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_4_0_7@example.com/">activity</a>: <script type="text/javascript">timeAgo(1546909200000);</script>.</div></summary>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_0_7@example.com/">test_4_0_7: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546909200000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_0_7@example.com/">introduced: v1.10..</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546909200000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li></li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_4_0_7@example.com/">https://lore.kernel.org/r/regzbot-testing-test_4_0_7@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.9..v1.11-rc1</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_4_0_6: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_0_6@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_4_0_6@example.com/">activity</a>: <script type="text/javascript">timeAgo(1546822800000);</script>.</div></summary>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_0_6@example.com/">test_4_0_6: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546822800000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_0_6@example.com/">introduced: v1.9..v1.11-rc1</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546822800000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li></li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_4_0_6@example.com/">https://lore.kernel.org/r/regzbot-testing-test_4_0_6@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.8..v1.9-rc1</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_4_0_4: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_0_4@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_4_0_4@example.com/">activity</a>: <script type="text/javascript">timeAgo(1546650000000);</script>.</div></summary>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_0_4@example.com/">test_4_0_4: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546650000000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_0_4@example.com/">introduced: v1.8..v1.9-rc1</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546650000000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li></li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_4_0_4@example.com/">https://lore.kernel.org/r/regzbot-testing-test_4_0_4@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.9..v1.10-rc2</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_4_0_2: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_0_2@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_4_0_2@example.com/">activity</a>: <script type="text/javascript">timeAgo(1546477200000);</script>.</div></summary>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_0_2@example.com/">test_4_0_2: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546477200000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_0_2@example.com/">introduced: v1.9..v1.10-rc2</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546477200000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li></li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_4_0_2@example.com/">https://lore.kernel.org/r/regzbot-testing-test_4_0_2@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>on back burner with activity in the past six months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+  </table>
+  <hr>
+  <p style="text-align: center">[compiled by <a href="https://linux-regtracking.leemhuis.info">regzbot</a> on 2019-01-31 01:00:00 (UTC). Wanna know more about regzbot? Then check out its <a href="https://gitlab.com/knurd42/regzbot/-/blob/main/docs/getting_started.md">getting started guide</a> or its <a href="https://gitlab.com/knurd42/regzbot/-/blob/main/docs/reference.md">reference documentation</a>.]</p>
+</body>
+-----END WEB offltest_4_3-----
+
+-----BEGIN WEB offltest_4_4-----
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+</head>
+<body>
+  <script src="../relativetime.js" type="text/javascript"></script>
+  <h1>Linux kernel regression status</h1>
+  <h2><a href="../next/">[next]</a>&nbsp;[mainline]&nbsp;<a href="../stable/">[stable/longterm]</a>&nbsp;•&nbsp;<a href="../new/">[new]</a>&nbsp;•&nbsp;<a href="../all/">[all]</a>&nbsp;•&nbsp;<a href="../resolved/">[resolved]</a>&nbsp;<a href="../inconclusive/">[inconclusive]</a>&nbsp;</h2>
+  <table style="width:100%;">
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>current cycle (v1.10.. aka v1.11-rc), culprit identified</strong>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>
+            <a href="https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?h=master&amp;id=23bde5c338c7d028609c1af64173853fb1b84018">23bde5c338c7</a>
+          </li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_4_4_0: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_4_0@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_4_4_0@example.com/">activity</a>: <a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_4_0@example.com/"><script type="text/javascript">timeAgo(1547859600000);</script></a> &amp; <a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_4_1@example.com/"><script type="text/javascript">timeAgo(1547946000000);</script></a>. Noteworthy: <a href="https://www.kernel.org/releases.html">[1]</a>.</div></summary>
+          <div>[1]: <i><a href="https://www.kernel.org/releases.html">Link somewhere</a></i><div style="padding-left: 3em;"><script type="text/javascript">timeAgo(1547946000000);</script>, by Regzbot testingmail</div></div>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_4_1@example.com/">test_4_4_1: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547946000000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_4_0@example.com/">test_4_4_0: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547859600000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_4_1@example.com/">relatebrief: https://www.kernel.org/releases.html Link somewhere</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547946000000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_4_0@example.com/">introduced: 23bde5c338c7d028609c1af64173853fb1b84018</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547859600000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li>Fixes: 23bde5c338c7 ("This is a mainline_master commit for testing regzbot, the content doesn't matter.")</li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_4_4_0@example.com/">https://lore.kernel.org/r/regzbot-testing-test_4_4_0@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>
+            <a href="https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?h=master&amp;id=23bde5c338c7d028609c1af64173853fb1b84018">23bde5c338c7</a>
+          </li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_4_0_1: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_0_1@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_4_0_1@example.com/">activity</a>: <script type="text/javascript">timeAgo(1546390800000);</script>.</div></summary>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_0_1@example.com/">test_4_0_1: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546390800000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_0_1@example.com/">introduced: 23bde5c338c7d028609c1af64173853fb1b84018</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546390800000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li>Fixes: 23bde5c338c7 ("This is a mainline_master commit for testing regzbot, the content doesn't matter.")</li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_4_0_1@example.com/">https://lore.kernel.org/r/regzbot-testing-test_4_0_1@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>current cycle (v1.10.. aka v1.11-rc), unknown culprit</strong>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.10..v1.11-rc1</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_4_4_10: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_4_10@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_4_4_10@example.com/">activity</a>: <a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_4_10@example.com/"><script type="text/javascript">timeAgo(1548723600000);</script></a> &amp; <a href="https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git/commit/?h=master&amp;id=62f89ca29d354a42662bc61fc2e63ee6af41b3fd"><script type="text/javascript">timeAgo(1577836803000);</script></a>. Noteworthy: <mark style="background-color: #D0D0D0;">[<a href="https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git/commit/?h=master&amp;id=62f89ca29d354a42662bc61fc2e63ee6af41b3fd">fix incoming</a>]</mark>.</div></summary>
+          <div>
+            <strong>Fix incoming: </strong>
+            <a href="https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git/commit/?h=master&amp;id=62f89ca29d354a42662bc61fc2e63ee6af41b3fd">
+              <i>62f89ca29d35 ("Testcommit test_4_4")</i>
+            </a>
+            <div style="padding-left: 3em;">
+              <script type="text/javascript">timeAgo(1577836803000);</script>
+            </div>
+          </div>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git/commit/?h=master&amp;id=62f89ca29d354a42662bc61fc2e63ee6af41b3fd">Commit 62f89ca29d35 in next</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1577836803000);</script>, by Regzbot Testing</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_4_10@example.com/">test_4_4_10: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1548723600000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git/commit/?h=master&amp;id=62f89ca29d354a42662bc61fc2e63ee6af41b3fd">fix: 62f89ca29d35 in next referred to this regression</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1577836803000);</script>, by Regzbot Testing</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_4_10@example.com/">introduced: v1.10..v1.11-rc1</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1548723600000);</script>, by Regzbot testingmail</div></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.10..v1.11-rc1</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_4_4_4: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_4_4@example.com/">Regzbot testingmail</a> and <a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_4_6@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_4_4_6@example.com/">activity</a>: <a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_4_4@example.com/"><script type="text/javascript">timeAgo(1548205200000);</script></a> &amp; <a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_4_7@example.com/"><script type="text/javascript">timeAgo(1548464400000);</script></a>. Noteworthy: <mark style="background-color: #D0D0D0;">[<a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_4_5@example.com/">fix incoming</a>]</mark>.</div></summary>
+          <div>
+            <strong>Fix incoming: </strong>
+            <a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_4_5@example.com/">
+              <i>1234567890ab</i>
+            </a>
+            <div style="padding-left: 3em;">
+              <script type="text/javascript">timeAgo(1548291600000);</script>
+            </div>
+          </div>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_4_7@example.com/">test_4_4_7: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1548464400000);</script>, by Regzbot testingmail [<a href="../regression/lore/regzbot-testing-test_4_4_6@example.com/">via dup</a>]</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_4_6@example.com/">test_4_4_6: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1548378000000);</script>, by Regzbot testingmail [<a href="../regression/lore/regzbot-testing-test_4_4_6@example.com/">via dup</a>]</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_4_5@example.com/">test_4_4_5: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1548291600000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_4_4@example.com/">test_4_4_4: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1548205200000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_4_7@example.com/">duplicate: https://lore.kernel.org/regressions/regzbot-testing-test_4_4_6@example.com/ [implicit via duplicate]</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1548464400000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_4_5@example.com/">fix: 1234567890abcdef1234567890abcdef</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1548291600000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_4_4@example.com/">introduced: v1.10..v1.11-rc1</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1548205200000);</script>, by Regzbot testingmail</div></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.10..v1.11-rc1</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_4_0_0: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_0_0@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_4_0_0@example.com/">activity</a>: <script type="text/javascript">timeAgo(1546304400000);</script>.</div></summary>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_0_0@example.com/">test_4_0_0: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546304400000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_0_0@example.com/">introduced: v1.10..v1.11-rc1</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546304400000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li></li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_4_0_0@example.com/">https://lore.kernel.org/r/regzbot-testing-test_4_0_0@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>previous cycle (v1.9..v1.10), culprit identified, with activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>
+            <a href="https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?h=master&amp;id=bff114a4835d9abd95a627c8e4d7613cc6be163b">bff114a4835d</a>
+            <div>(v1.10^0)</div>
+          </li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_4_0_3: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_0_3@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_4_0_3@example.com/">activity</a>: <script type="text/javascript">timeAgo(1546563600000);</script>.</div></summary>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_0_3@example.com/">test_4_0_3: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546563600000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_0_3@example.com/">introduced: bff114a4835d9abd95a627c8e4d7613cc6be163b</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546563600000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li>Fixes: bff114a4835d ("This is a mainline_master commit for testing regzbot, the content doesn't matter.")</li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_4_0_3@example.com/">https://lore.kernel.org/r/regzbot-testing-test_4_0_3@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>older cycles (..v1.9), culprit identified, with activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>
+            <a href="https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?h=master&amp;id=2c5fa4b5edeb0693443b2f93a80980052eef7b58">2c5fa4b5edeb</a>
+            <div>(v1.9-rc2^0)</div>
+          </li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_4_0_5: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_0_5@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_4_0_5@example.com/">activity</a>: <script type="text/javascript">timeAgo(1546736400000);</script>.</div></summary>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_0_5@example.com/">test_4_0_5: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546736400000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_0_5@example.com/">introduced: 2c5fa4b5edeb0693443b2f93a80980052eef7b58</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546736400000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li>Fixes: 2c5fa4b5edeb ("This is a mainline_master commit for testing regzbot, the content doesn't matter.")</li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_4_0_5@example.com/">https://lore.kernel.org/r/regzbot-testing-test_4_0_5@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>previous cycle (v1.9..v1.10), unknown culprit, with activity in the past three weeks</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>older cycles (..v1.9), unknown culprit, with activity in the past three weeks</strong>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>123456789012</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_4_3_1: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_3_1@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_4_3_1@example.com/">activity</a>: <script type="text/javascript">timeAgo(1547773200000);</script>.</div></summary>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_3_1@example.com/">test_4_3_1: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547773200000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_3_1@example.com/">introduced: 123456789012</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547773200000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li></li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_4_3_1@example.com/">https://lore.kernel.org/r/regzbot-testing-test_4_3_1@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v0.10..v0.11</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_4_3_0: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_3_0@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_4_3_0@example.com/">activity</a>: <script type="text/javascript">timeAgo(1547686800000);</script>.</div></summary>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_3_0@example.com/">test_4_3_0: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547686800000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_3_0@example.com/">introduced: v0.10..v0.11</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547686800000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li></li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_4_3_0@example.com/">https://lore.kernel.org/r/regzbot-testing-test_4_3_0@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.9.2..v1.10</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_4_2_4: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_2_4@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_4_2_4@example.com/">activity</a>: <script type="text/javascript">timeAgo(1547600400000);</script>.</div></summary>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_2_4@example.com/">test_4_2_4: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547600400000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_2_4@example.com/">introduced: v1.9.2..v1.10</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547600400000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li></li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_4_2_4@example.com/">https://lore.kernel.org/r/regzbot-testing-test_4_2_4@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.10.2..v1.11-rc1</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_4_2_3: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_2_3@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_4_2_3@example.com/">activity</a>: <script type="text/javascript">timeAgo(1547514000000);</script>.</div></summary>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_2_3@example.com/">test_4_2_3: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547514000000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_2_3@example.com/">introduced: v1.10.2..v1.11-rc1</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547514000000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li></li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_4_2_3@example.com/">https://lore.kernel.org/r/regzbot-testing-test_4_2_3@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.8..v1.8.1</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_4_2_2: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_2_2@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_4_2_2@example.com/">activity</a>: <script type="text/javascript">timeAgo(1547427600000);</script>.</div></summary>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_2_2@example.com/">test_4_2_2: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547427600000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_2_2@example.com/">introduced: v1.8..v1.8.1</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1547427600000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li></li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_4_2_2@example.com/">https://lore.kernel.org/r/regzbot-testing-test_4_2_2@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>all others with unknown culprit and activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.10..23bde5c338c7</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_4_0_7: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_0_7@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_4_0_7@example.com/">activity</a>: <script type="text/javascript">timeAgo(1546909200000);</script>.</div></summary>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_0_7@example.com/">test_4_0_7: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546909200000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_0_7@example.com/">introduced: v1.10..</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546909200000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li></li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_4_0_7@example.com/">https://lore.kernel.org/r/regzbot-testing-test_4_0_7@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.9..v1.11-rc1</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_4_0_6: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_0_6@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_4_0_6@example.com/">activity</a>: <script type="text/javascript">timeAgo(1546822800000);</script>.</div></summary>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_0_6@example.com/">test_4_0_6: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546822800000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_0_6@example.com/">introduced: v1.9..v1.11-rc1</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546822800000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li></li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_4_0_6@example.com/">https://lore.kernel.org/r/regzbot-testing-test_4_0_6@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.8..v1.9-rc1</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_4_0_4: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_0_4@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_4_0_4@example.com/">activity</a>: <script type="text/javascript">timeAgo(1546650000000);</script>.</div></summary>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_0_4@example.com/">test_4_0_4: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546650000000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_0_4@example.com/">introduced: v1.8..v1.9-rc1</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546650000000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li></li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_4_0_4@example.com/">https://lore.kernel.org/r/regzbot-testing-test_4_0_4@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.9..v1.10-rc2</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_4_0_2: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_0_2@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_4_0_2@example.com/">activity</a>: <script type="text/javascript">timeAgo(1546477200000);</script>.</div></summary>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_0_2@example.com/">test_4_0_2: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546477200000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_4_0_2@example.com/">introduced: v1.9..v1.10-rc2</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546477200000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li></li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_4_0_2@example.com/">https://lore.kernel.org/r/regzbot-testing-test_4_0_2@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>on back burner with activity in the past six months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+  </table>
+  <hr>
+  <p style="text-align: center">[compiled by <a href="https://linux-regtracking.leemhuis.info">regzbot</a> on 2019-01-31 01:00:00 (UTC). Wanna know more about regzbot? Then check out its <a href="https://gitlab.com/knurd42/regzbot/-/blob/main/docs/getting_started.md">getting started guide</a> or its <a href="https://gitlab.com/knurd42/regzbot/-/blob/main/docs/reference.md">reference documentation</a>.]</p>
+</body>
+-----END WEB offltest_4_4-----
+
+-----BEGIN WEB offltest_5_0-----
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+</head>
+<body>
+  <script src="../relativetime.js" type="text/javascript"></script>
+  <h1>Linux kernel regression status</h1>
+  <h2><a href="../next/">[next]</a>&nbsp;[mainline]&nbsp;<a href="../stable/">[stable/longterm]</a>&nbsp;•&nbsp;<a href="../new/">[new]</a>&nbsp;•&nbsp;<a href="../all/">[all]</a>&nbsp;•&nbsp;<a href="../resolved/">[resolved]</a>&nbsp;<a href="../inconclusive/">[inconclusive]</a>&nbsp;</h2>
+  <table style="width:100%;">
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>current cycle (v1.10.. aka v1.11-rc), culprit identified</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>current cycle (v1.10.. aka v1.11-rc), unknown culprit</strong>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.10..v1.11-rc1</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_5_0: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_5_0@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_5_0@example.com/">activity</a>: <script type="text/javascript">timeAgo(1546304400000);</script>.</div></summary>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_5_0@example.com/">test_5_0: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546304400000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_5_0@example.com/">introduced: v1.10..v1.11-rc1</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546304400000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li></li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_5_0@example.com/">https://lore.kernel.org/r/regzbot-testing-test_5_0@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>previous cycle (v1.9..v1.10), culprit identified, with activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>older cycles (..v1.9), culprit identified, with activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>previous cycle (v1.9..v1.10), unknown culprit, with activity in the past three weeks</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>older cycles (..v1.9), unknown culprit, with activity in the past three weeks</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>all others with unknown culprit and activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>on back burner with activity in the past six months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+  </table>
+  <hr>
+  <p style="text-align: center">[compiled by <a href="https://linux-regtracking.leemhuis.info">regzbot</a> on 2019-01-31 01:00:00 (UTC). Wanna know more about regzbot? Then check out its <a href="https://gitlab.com/knurd42/regzbot/-/blob/main/docs/getting_started.md">getting started guide</a> or its <a href="https://gitlab.com/knurd42/regzbot/-/blob/main/docs/reference.md">reference documentation</a>.]</p>
+</body>
+-----END WEB offltest_5_0-----
+
+-----BEGIN WEB offltest_5_1-----
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+</head>
+<body>
+  <script src="../relativetime.js" type="text/javascript"></script>
+  <h1>Linux kernel regression status</h1>
+  <h2><a href="../next/">[next]</a>&nbsp;[mainline]&nbsp;<a href="../stable/">[stable/longterm]</a>&nbsp;•&nbsp;<a href="../new/">[new]</a>&nbsp;•&nbsp;<a href="../all/">[all]</a>&nbsp;•&nbsp;<a href="../resolved/">[resolved]</a>&nbsp;<a href="../inconclusive/">[inconclusive]</a>&nbsp;</h2>
+  <table style="width:100%;">
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>current cycle (v1.10.. aka v1.11-rc), culprit identified</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>current cycle (v1.10.. aka v1.11-rc), unknown culprit</strong>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.10..v1.11-rc1</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_5_0: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_5_0@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_5_0@example.com/">activity</a>: <a href="https://lore.kernel.org/regressions/regzbot-testing-test_5_0@example.com/"><script type="text/javascript">timeAgo(1546304400000);</script></a> &amp; <a href="https://lore.kernel.org/regressions/regzbot-testing-test_5_1_0@example.com/"><script type="text/javascript">timeAgo(1546390800000);</script></a>.</div></summary>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_5_1_0@example.com/">test_5_1_0: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546390800000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_5_0@example.com/">test_5_0: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546304400000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_5_0@example.com/">introduced: v1.10..v1.11-rc1</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546304400000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li></li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_5_0@example.com/">https://lore.kernel.org/r/regzbot-testing-test_5_0@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>previous cycle (v1.9..v1.10), culprit identified, with activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>older cycles (..v1.9), culprit identified, with activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>previous cycle (v1.9..v1.10), unknown culprit, with activity in the past three weeks</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>older cycles (..v1.9), unknown culprit, with activity in the past three weeks</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>all others with unknown culprit and activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>on back burner with activity in the past six months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+  </table>
+  <hr>
+  <p style="text-align: center">[compiled by <a href="https://linux-regtracking.leemhuis.info">regzbot</a> on 2019-01-31 01:00:00 (UTC). Wanna know more about regzbot? Then check out its <a href="https://gitlab.com/knurd42/regzbot/-/blob/main/docs/getting_started.md">getting started guide</a> or its <a href="https://gitlab.com/knurd42/regzbot/-/blob/main/docs/reference.md">reference documentation</a>.]</p>
+  <p style="text-align: center">[recently <a href="../unhandled/">2 events occurred that regzbot was unable to handle</a>]</p>
+</body>
+-----END WEB offltest_5_1-----
+
+-----BEGIN WEB offltest_5_2-----
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+</head>
+<body>
+  <script src="../relativetime.js" type="text/javascript"></script>
+  <h1>Linux kernel regression status</h1>
+  <h2><a href="../next/">[next]</a>&nbsp;[mainline]&nbsp;<a href="../stable/">[stable/longterm]</a>&nbsp;•&nbsp;<a href="../new/">[new]</a>&nbsp;•&nbsp;<a href="../all/">[all]</a>&nbsp;•&nbsp;<a href="../resolved/">[resolved]</a>&nbsp;<a href="../inconclusive/">[inconclusive]</a>&nbsp;</h2>
+  <table style="width:100%;">
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>current cycle (v1.10.. aka v1.11-rc), culprit identified</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>current cycle (v1.10.. aka v1.11-rc), unknown culprit</strong>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.10..v1.11-rc1</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_5_0: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_5_0@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_5_0@example.com/">activity</a>: <a href="https://lore.kernel.org/regressions/regzbot-testing-test_5_0@example.com/"><script type="text/javascript">timeAgo(1546304400000);</script></a> &amp; <a href="https://lore.kernel.org/regressions/regzbot-testing-test_5_2_4@example.com/"><script type="text/javascript">timeAgo(1546909200000);</script></a>.</div></summary>
+          <p>Latest five known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_5_2_4@example.com/">test_5_2_4: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546909200000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_5_2_3@example.com/">test_5_2_3: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546822800000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_5_2_2@example.com/">test_5_2_2: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546736400000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_5_2_1@example.com/">test_5_2_1: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546650000000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_5_2_0@example.com/">test_5_2_0: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546563600000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_5_2_2@example.com/">unrelate: http://lore.kernel.org/somelist_somemsgid/</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546736400000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_5_2_1@example.com/">relate: http://lore.kernel.org/somelist/somemsgid/</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546650000000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_5_2_0@example.com/">relate: http://lore.kernel.org/somelist_somemsgid/</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546563600000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_5_0@example.com/">introduced: v1.10..v1.11-rc1</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546304400000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li></li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_5_0@example.com/">https://lore.kernel.org/r/regzbot-testing-test_5_0@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>previous cycle (v1.9..v1.10), culprit identified, with activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>older cycles (..v1.9), culprit identified, with activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>previous cycle (v1.9..v1.10), unknown culprit, with activity in the past three weeks</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>older cycles (..v1.9), unknown culprit, with activity in the past three weeks</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>all others with unknown culprit and activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>on back burner with activity in the past six months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+  </table>
+  <hr>
+  <p style="text-align: center">[compiled by <a href="https://linux-regtracking.leemhuis.info">regzbot</a> on 2019-01-31 01:00:00 (UTC). Wanna know more about regzbot? Then check out its <a href="https://gitlab.com/knurd42/regzbot/-/blob/main/docs/getting_started.md">getting started guide</a> or its <a href="https://gitlab.com/knurd42/regzbot/-/blob/main/docs/reference.md">reference documentation</a>.]</p>
+  <p style="text-align: center">[recently <a href="../unhandled/">7 events occurred that regzbot was unable to handle</a>]</p>
+</body>
+-----END WEB offltest_5_2-----
+
+-----BEGIN WEB offltest_6_0-----
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+</head>
+<body>
+  <script src="../relativetime.js" type="text/javascript"></script>
+  <h1>Linux kernel regression status</h1>
+  <h2><a href="../next/">[next]</a>&nbsp;[mainline]&nbsp;<a href="../stable/">[stable/longterm]</a>&nbsp;•&nbsp;<a href="../new/">[new]</a>&nbsp;•&nbsp;<a href="../all/">[all]</a>&nbsp;•&nbsp;<a href="../resolved/">[resolved]</a>&nbsp;<a href="../inconclusive/">[inconclusive]</a>&nbsp;</h2>
+  <table style="width:100%;">
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>current cycle (v1.10.. aka v1.11-rc), culprit identified</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>current cycle (v1.10.. aka v1.11-rc), unknown culprit</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>previous cycle (v1.9..v1.10), culprit identified, with activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>older cycles (..v1.9), culprit identified, with activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>previous cycle (v1.9..v1.10), unknown culprit, with activity in the past three weeks</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>older cycles (..v1.9), unknown culprit, with activity in the past three weeks</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>all others with unknown culprit and activity in the past three months</strong>
+      </td>
+    </tr>
+    <tr style="vertical-align:top;">
+      <td style="width: 200px;">
+        <div style="padding-left: 1em;">
+          <li>v1.8..v1.9-rc1</li>
+        </div>
+      </td>
+      <td>
+        <details id="regression-details" style="padding-left: 1em;">
+          <summary style="list-style-position: outside;"><strong><i>test_6_0: Lorem ipsum dolor sit amet</i></strong> by <a href="https://lore.kernel.org/regressions/regzbot-testing-test_6_0@example.com/">Regzbot testingmail</a><div>Earliest &amp; latest <a href="../regression/lore/regzbot-testing-test_6_0@example.com/">activity</a>: <a href="https://lore.kernel.org/regressions/regzbot-testing-test_6_0@example.com/"><script type="text/javascript">timeAgo(1546304400000);</script></a> &amp; <a href="https://lore.kernel.org/regressions/regzbot-testing-test_6_0_3@example.com/"><script type="text/javascript">timeAgo(1546477200000);</script></a>. Noteworthy: <a href="https://www.kernel.org/releases.html">[1]</a>.</div></summary>
+          <div>[1]: <i><a href="https://www.kernel.org/releases.html">Some link</a></i><div style="padding-left: 3em;"><script type="text/javascript">timeAgo(1546390800000);</script>, by Regzbot testingmail</div></div>
+          <p>All known activities:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_6_0_3@example.com/">test_6_0_3: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546477200000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_6_0_1@example.com/">test_6_0_1: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546390800000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_6_0@example.com/">test_6_0: Lorem ipsum dolor sit amet</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546304400000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>Regzbot command history:<ul style="padding-left: 5px; margin-top: -1em;"><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_6_0_1@example.com/">note: note before delete</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546390800000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_6_0_1@example.com/">relatebrief: https://www.kernel.org/releases.html Some link</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546390800000);</script>, by Regzbot testingmail</div></li><li style="list-style-position: inside;"><i><a href="https://lore.kernel.org/regressions/regzbot-testing-test_6_0@example.com/">introduced: v1.8..v1.9-rc1</a></i><div style="padding-left: 2em;"><script type="text/javascript">timeAgo(1546304400000);</script>, by Regzbot testingmail</div></li></ul></p>
+          <p>When fixing, add this to the commit message to make regzbot notice patch postings and commits to resolve the issue:<ul style="padding-left: 1em; margin-top: -1em; font-style: italic; list-style-type: none;"><li></li><li>Reported-by: Regzbot testingmail &lt;nobody@example.com&gt;</li><li>Link: <a href="https://lore.kernel.org/r/regzbot-testing-test_6_0@example.com/">https://lore.kernel.org/r/regzbot-testing-test_6_0@example.com/</a></li></ul></p>
+        </details>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">
+        <hr>
+        <strong>on back burner with activity in the past six months</strong>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="3" style="text-align: left;  padding-bottom: 1em;">none known by regzbot</td>
+    </tr>
+  </table>
+  <hr>
+  <p style="text-align: center">[compiled by <a href="https://linux-regtracking.leemhuis.info">regzbot</a> on 2019-01-31 01:00:00 (UTC). Wanna know more about regzbot? Then check out its <a href="https://gitlab.com/knurd42/regzbot/-/blob/main/docs/getting_started.md">getting started guide</a> or its <a href="https://gitlab.com/knurd42/regzbot/-/blob/main/docs/reference.md">reference documentation</a>.]</p>
+</body>
+-----END WEB offltest_6_0-----
+
+-----BEGIN WEB offltest_6_1-----
+-----END WEB offltest_6_1-----
+


### PR DESCRIPTION
Increase coverage test on offline testing.
testing_offline has gone from 61% to 69% total coverage.

We are now including:
  * mail/web exporting check.
  * deletion check.

```
Name Stmts Miss Cover
----------------------------------------------------------------   
regzbot/__init__.py 2022 461 77%
regzbot/_rbcmd.py 366 44 88%
regzbot/_repsources/_bugzilla.py 332 276 17%
regzbot/_repsources/_generic.py 23 0 100%
regzbot/_repsources/_github.py 303 244 19%
regzbot/_repsources/_gitlab.py 309 251 19%
regzbot/_repsources/_lore.py 409 132 68%
regzbot/_repsources/_trackers.py 77 55 29%
regzbot/commandl.py 86 11 87%
regzbot/export_csv.py 93 2 98%
regzbot/export_mail.py 345 42 88%
regzbot/export_web.py 720 40 94%
----------------------------------------------------------------   
TOTAL 5085 1558 69%
```
The _repsources/*.py files should be more effectively covered by testing_trackers.py.

## How to run
### Execute tests
`PYTHONPATH=. coverage run regzbot/commandl.py test --offline`
### Compile report
`coverage report`
